### PR TITLE
Fix auth to use UUID instead of string for userId's

### DIFF
--- a/apps/backend/drizzle/0000_chief_strong_guy.sql
+++ b/apps/backend/drizzle/0000_chief_strong_guy.sql
@@ -2,7 +2,7 @@ CREATE TABLE "account" (
 	"id" text PRIMARY KEY NOT NULL,
 	"accountId" text NOT NULL,
 	"providerId" text NOT NULL,
-	"userId" text NOT NULL,
+	"userId" uuid NOT NULL,
 	"accessToken" text,
 	"refreshToken" text,
 	"idToken" text,
@@ -24,7 +24,7 @@ CREATE TABLE "rateLimit" (
 CREATE TABLE "session" (
 	"id" text PRIMARY KEY NOT NULL,
 	"token" text NOT NULL,
-	"userId" text NOT NULL,
+	"userId" uuid NOT NULL,
 	"expiresAt" timestamp with time zone NOT NULL,
 	"ipAddress" text,
 	"userAgent" text,
@@ -34,7 +34,7 @@ CREATE TABLE "session" (
 );
 --> statement-breakpoint
 CREATE TABLE "user" (
-	"id" text PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"name" text NOT NULL,
 	"email" text NOT NULL,
 	"emailVerified" boolean DEFAULT false NOT NULL,

--- a/apps/backend/src/auth/auth.ts
+++ b/apps/backend/src/auth/auth.ts
@@ -346,6 +346,9 @@ export function createAuth(input: CreateAuthInput): AuthInstance {
             data: Record<string, unknown>,
             ctx: Record<string, unknown> | null,
           ) => {
+            // generate uuid
+            if (!data.id) data.id = crypto.randomUUID();
+
             const contextObj = ctx?.context as
               | Record<string, unknown>
               | undefined;

--- a/apps/backend/src/auth/session.decorator.ts
+++ b/apps/backend/src/auth/session.decorator.ts
@@ -1,10 +1,9 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import type { RequestWithSession } from './auth.guard';
 
-type UUID = string & { readonly __brand: 'UUID' };
 export interface SessionData {
   user: {
-    id: UUID;
+    id: string;
     name: string;
     email: string;
     emailVerified: boolean;

--- a/apps/backend/src/auth/session.decorator.ts
+++ b/apps/backend/src/auth/session.decorator.ts
@@ -1,9 +1,10 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import type { RequestWithSession } from './auth.guard';
 
+type UUID = string & { readonly __brand: 'UUID' };
 export interface SessionData {
   user: {
-    id: string;
+    id: UUID;
     name: string;
     email: string;
     emailVerified: boolean;

--- a/apps/backend/src/db/database-seed.service.ts
+++ b/apps/backend/src/db/database-seed.service.ts
@@ -76,7 +76,7 @@ export class DatabaseSeedService {
   }
 
   private async seedDefaultSystemAdmin(): Promise<void> {
-    const seedUserId = '00000000-0000-0000-0000-000000000001'; // Fixed UUID for system admin
+    const seedUserId = '00000000-0000-0000-0000-000000000001'; //admin uuid
     const seedName =
       this.configService.get<string>('SEED_SYSTEM_ADMIN_NAME') ??
       'System Admin';

--- a/apps/backend/src/db/database-seed.service.ts
+++ b/apps/backend/src/db/database-seed.service.ts
@@ -76,7 +76,7 @@ export class DatabaseSeedService {
   }
 
   private async seedDefaultSystemAdmin(): Promise<void> {
-    const seedUserId = 'seed-system-admin';
+    const seedUserId = '00000000-0000-0000-0000-000000000001'; // Fixed UUID for system admin
     const seedName =
       this.configService.get<string>('SEED_SYSTEM_ADMIN_NAME') ??
       'System Admin';

--- a/apps/backend/src/db/seeds/auth.seed.ts
+++ b/apps/backend/src/db/seeds/auth.seed.ts
@@ -21,13 +21,13 @@ export class AuthSeed implements ISeedMigration {
   name = 'auth-seed';
   private readonly logger = new Logger('AuthSeed');
 
-  // Test user IDs (use consistent IDs for reliable testing)
+  // Test user IDs (use consistent UUIDs for reliable testing)
   private readonly testUserIds = {
-    student: 'test-student-001',
-    studentTwo: 'test-student-002',
-    lecturer: 'test-lecturer-001',
-    uniAdmin: 'test-uni-admin-001',
-    sysAdmin: 'test-sys-admin-001',
+    student: '550e8400-e29b-41d4-a716-446655440001',
+    studentTwo: '550e8400-e29b-41d4-a716-446655440002',
+    lecturer: '550e8400-e29b-41d4-a716-446655440003',
+    uniAdmin: '550e8400-e29b-41d4-a716-446655440004',
+    sysAdmin: '550e8400-e29b-41d4-a716-446655440005',
   };
 
   private readonly testSessionIds = {

--- a/apps/backend/src/entities/auth/auth.schema.ts
+++ b/apps/backend/src/entities/auth/auth.schema.ts
@@ -8,12 +8,13 @@ import {
   uniqueIndex,
   integer,
   bigint,
+  uuid,
 } from 'drizzle-orm/pg-core';
 
 export const usersTable = pgTable(
   'user',
   {
-    id: text('id').primaryKey(),
+    id: uuid('id').primaryKey().defaultRandom(),
     name: text('name').notNull(),
     email: text('email').notNull(),
     emailVerified: boolean('emailVerified').notNull().default(false),
@@ -40,7 +41,7 @@ export const sessionsTable = pgTable(
   {
     id: text('id').primaryKey(),
     token: text('token').notNull(),
-    userId: text('userId')
+    userId: uuid('userId')
       .notNull()
       .references(() => usersTable.id, { onDelete: 'cascade' }),
     expiresAt: timestamp('expiresAt', { withTimezone: true }).notNull(),
@@ -67,7 +68,7 @@ export const accountsTable = pgTable(
     id: text('id').primaryKey(),
     accountId: text('accountId').notNull(),
     providerId: text('providerId').notNull(),
-    userId: text('userId')
+    userId: uuid('userId')
       .notNull()
       .references(() => usersTable.id, { onDelete: 'cascade' }),
     accessToken: text('accessToken'),


### PR DESCRIPTION
Had to adapt auth schema aswell as seeding and auth.ts to ensure that user id is a uuid and not a string.

Endpoints are unit tested, and tested on swagger and now work perfectly with the auth implementation.









:(