### PR TITLE
Fix/frontend fixes

### DIFF
--- a/apps/frontend/src/__tests__/components/GenerateStep.test.tsx
+++ b/apps/frontend/src/__tests__/components/GenerateStep.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { GenerateStep } from "@/components/organisms/builder/GenerateStep";
+
+describe("GenerateStep props testing", () => {
+  it("change name for button when edit is enabled", () => {
+    render(
+      <GenerateStep
+        modules={[]}
+        events={[]}
+        onGenerate={jest.fn()}
+        isGenerating={false}
+        isEditMode={true}
+        timetableName="Timetable"
+        setTimetableName={jest.fn()}
+        selectedEventIds={[1]}
+        setSelectedEventIds={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /edit schedule/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/builder/page.tsx
+++ b/apps/frontend/src/app/builder/page.tsx
@@ -1,13 +1,20 @@
-import React from "react";
+import React, { Suspense } from "react";
 import { WizardShell } from "@/components/templates/builder/WizardShell";
-import { Suspense } from "react";
 
 export const metadata = { title: "Builder" };
 
 export default function BuilderPage() {
   return (
     <div className="h-[calc(100vh-var(--nav-height))] bg-[var(--bg-base)]">
-      <WizardShell />
+      <Suspense
+        fallback={
+          <div className="p-3 text-center">
+            Builder is loading, please be patient
+          </div>
+        }
+      >
+        <WizardShell />
+      </Suspense>
     </div>
   );
 }

--- a/apps/frontend/src/app/builder/page.tsx
+++ b/apps/frontend/src/app/builder/page.tsx
@@ -6,12 +6,8 @@ export const metadata = { title: "Builder" };
 
 export default function BuilderPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="h-[calc(100vh-var(--nav-height))] bg-[var(--bg-base)]">
-          <WizardShell />
-        </div>
-      }
-    ></Suspense>
+    <div className="h-[calc(100vh-var(--nav-height))] bg-[var(--bg-base)]">
+      <WizardShell />
+    </div>
   );
 }

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -127,7 +127,7 @@ function DashboardContent() {
               University Modular Timetable &amp; Analytics System
             </Badge>
 
-            <h1 className="text-4xl lg:text-5xl font-semibold text-[var(--text-primary)] leading-[1.1] suppressHydrationWarning">
+            <h1 className="text-4xl lg:text-5xl font-semibold text-[var(--text-primary)] leading-[1.1] suppressHydrationWarning={true}">
               {renderGreeting()}
             </h1>
 

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { DM_Sans } from "next/font/google";
 import { AppShellTemplate } from "@/components/templates/app/AppShellTemplate";
 import "./globals.css";
 import { Toaster } from "sonner";
+import Script from "next/script";
 
 const dmSans = DM_Sans({
   subsets: ["latin"],
@@ -43,7 +44,8 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <head suppressHydrationWarning>
-        <script
+        <Script
+          id="veryUnIqueIDBro"
           dangerouslySetInnerHTML={{
             __html: `
             (function() {

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { DM_Sans } from "next/font/google";
 //import { auth } from "@/../utilities/auth";
 import { AppShellTemplate } from "@/components/templates/app/AppShellTemplate";
 import "./globals.css";
+import { Toaster } from "sonner";
 
 const dmSans = DM_Sans({
   subsets: ["latin"],
@@ -57,6 +58,8 @@ export default async function RootLayout({
       </head>
       <body className="min-h-full flex flex-col">
         <AppShellTemplate userName={userName}>{children}</AppShellTemplate>
+
+        <Toaster />
       </body>
     </html>
   );

--- a/apps/frontend/src/hooks/errorListener.ts
+++ b/apps/frontend/src/hooks/errorListener.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { errorName, type ErrorPayload } from "../../utilities/errorCries";
+
+export const useErrorListener = () => {
+  useEffect(() => {
+    const globalErrorHandler = (event: Event) => {
+      const CustomEvent = event as CustomEvent<ErrorPayload>;
+      const { debugError, userMessage } = CustomEvent.detail;
+
+      console.error(`[Error man]: ${debugError}`);
+
+      //the actual UI that gets rendered once the error is emitted by errorCries.ts
+      toast.error(userMessage);
+    };
+
+    //site listens for this
+    window.addEventListener(errorName, globalErrorHandler);
+
+    //site stops listening for this
+    return () => window.removeEventListener(errorName, globalErrorHandler);
+  }, []);
+};

--- a/apps/frontend/utilities/errorCries.ts
+++ b/apps/frontend/utilities/errorCries.ts
@@ -1,0 +1,13 @@
+export interface ErrorPayload {
+  debugError: string; //actual error
+  userMessage: string; //message we send the users
+}
+
+export const errorName = "app:error";
+
+//this function gets called whenever an error is thrown
+
+export const throwError = (payload: ErrorPayload) => {
+  const err = new CustomEvent<ErrorPayload>(errorName, { detail: payload });
+  window.dispatchEvent(err);
+};


### PR DESCRIPTION
Added a custom hook for errors. Frontend would use this hook instead of console error logs for example, then a sonner (toast) will pop up on the screen. This toast can be customised to be however pretty we want it to be while keeping the error emission and catching the same. Finished issue #317 