### PR TITLE
Add S3 object storage backend

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -52,7 +52,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "shared-types": "workspace:*",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
@@ -82,8 +83,7 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.59.4",
-    "zod": "^4.4.3"
+    "typescript-eslint": "^8.59.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/apps/backend/src/storage/object-storage.service.spec.ts
+++ b/apps/backend/src/storage/object-storage.service.spec.ts
@@ -1,0 +1,83 @@
+import { ConfigService } from '@nestjs/config';
+import { ObjectStorageService } from './object-storage.service';
+import type { ObjectStorageClient } from './object-storage.service';
+
+class TestConfigService {
+  constructor(private readonly env: Record<string, string>) {}
+
+  get<T = string>(key: string): T | undefined {
+    return this.env[key] as T | undefined;
+  }
+}
+
+function createConfigService(env: Record<string, string>): ConfigService {
+  return new TestConfigService(env) as unknown as ConfigService;
+}
+
+function createClient(
+  handleCommand: (commandName: string) => unknown = () => ({}),
+): { calls: string[]; client: ObjectStorageClient } {
+  const calls: string[] = [];
+
+  return {
+    calls,
+    client: {
+      send: (command) => {
+        const commandName = command.constructor.name;
+        calls.push(commandName);
+        return Promise.resolve().then(() => handleCommand(commandName));
+      },
+    },
+  };
+}
+
+function missingBucketError(): Error {
+  return Object.assign(new Error('Bucket not found'), {
+    name: 'NotFound',
+    $metadata: { httpStatusCode: 404 },
+  });
+}
+
+describe('ObjectStorageService', () => {
+  it('creates the configured bucket when it does not exist', async () => {
+    const { calls, client } = createClient((commandName) => {
+      if (commandName === 'HeadBucketCommand') {
+        throw missingBucketError();
+      }
+
+      return {};
+    });
+
+    const service = new ObjectStorageService(
+      createConfigService({ MINIO_BUCKET: 'umtas-uploads' }),
+      client,
+    );
+
+    await service.onModuleInit();
+
+    expect(calls).toEqual(['HeadBucketCommand', 'CreateBucketCommand']);
+  });
+
+  it('does not create the bucket when it already exists', async () => {
+    const { calls, client } = createClient();
+
+    const service = new ObjectStorageService(
+      createConfigService({ MINIO_BUCKET: 'umtas-uploads' }),
+      client,
+    );
+
+    await service.onModuleInit();
+
+    expect(calls).toEqual(['HeadBucketCommand']);
+  });
+
+  it('skips setup when no bucket is configured', async () => {
+    const { calls, client } = createClient();
+
+    const service = new ObjectStorageService(createConfigService({}), client);
+
+    await service.onModuleInit();
+
+    expect(calls).toEqual([]);
+  });
+});

--- a/apps/backend/src/storage/object-storage.service.ts
+++ b/apps/backend/src/storage/object-storage.service.ts
@@ -119,15 +119,15 @@ function isMissingBucketError(error: unknown): boolean {
   return (
     errorDetails.$metadata?.httpStatusCode === 404 ||
     (typeof errorDetails.name === 'string' &&
-      MISSING_BUCKET_ERROR_NAMES.includes(errorDetails.name))
+      MISSING_BUCKET_ERROR_NAMES.has(errorDetails.name))
   );
 }
 
-const MISSING_BUCKET_ERROR_NAMES = [
+const MISSING_BUCKET_ERROR_NAMES = new Set([
   'NotFound',
   'NoSuchBucket',
   'NotFoundError',
-];
+]);
 
 function isObject(value: unknown): value is object {
   return typeof value === 'object' && value !== null;

--- a/apps/backend/src/storage/object-storage.service.ts
+++ b/apps/backend/src/storage/object-storage.service.ts
@@ -1,6 +1,7 @@
 import {
   CreateBucketCommand,
   HeadBucketCommand,
+  PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
 import {
@@ -18,7 +19,9 @@ import {
 } from './storage.config';
 
 export interface ObjectStorageClient {
-  send(command: HeadBucketCommand | CreateBucketCommand): Promise<unknown>;
+  send(
+    command: HeadBucketCommand | CreateBucketCommand | PutObjectCommand,
+  ): Promise<unknown>;
 }
 
 export const OBJECT_STORAGE_CLIENT = Symbol('OBJECT_STORAGE_CLIENT');
@@ -71,6 +74,28 @@ export class ObjectStorageService implements OnModuleInit {
 
       throw error;
     }
+  }
+
+  async putObject(options: {
+    key: string;
+    body: Buffer | Uint8Array;
+    contentType?: string;
+  }): Promise<{ bucket: string; key: string }> {
+    if (!this.config.bucket) {
+      throw new Error('Object storage bucket is not configured');
+    }
+
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.config.bucket,
+        Key: options.key,
+        Body: options.body,
+        ContentLength: options.body.byteLength,
+        ContentType: options.contentType,
+      }),
+    );
+
+    return { bucket: this.config.bucket, key: options.key };
   }
 
   private async createBucket(): Promise<void> {

--- a/apps/backend/src/storage/object-storage.service.ts
+++ b/apps/backend/src/storage/object-storage.service.ts
@@ -1,0 +1,109 @@
+import {
+  CreateBucketCommand,
+  HeadBucketCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleInit,
+  Optional,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  buildObjectStorageConfig,
+  buildS3ClientConfig,
+  type ObjectStorageConfig,
+} from './storage.config';
+
+export interface ObjectStorageClient {
+  send(command: HeadBucketCommand | CreateBucketCommand): Promise<unknown>;
+}
+
+export const OBJECT_STORAGE_CLIENT = Symbol('OBJECT_STORAGE_CLIENT');
+
+@Injectable()
+export class ObjectStorageService implements OnModuleInit {
+  private readonly logger = new Logger(ObjectStorageService.name);
+  private readonly config: ObjectStorageConfig;
+  private readonly client: ObjectStorageClient;
+
+  constructor(
+    configService: ConfigService,
+    @Optional()
+    @Inject(OBJECT_STORAGE_CLIENT)
+    client?: ObjectStorageClient,
+  ) {
+    this.config = buildObjectStorageConfig((key) =>
+      configService.get<string>(key),
+    );
+    this.client = client ?? new S3Client(buildS3ClientConfig(this.config));
+  }
+
+  async onModuleInit(): Promise<void> {
+    if (!this.config.bucket) {
+      this.logger.warn(
+        'Object storage bucket is not configured; skipping setup',
+      );
+      return;
+    }
+
+    if (!this.config.createBucketOnStartup) {
+      this.logger.log('Object storage bucket creation is disabled');
+      return;
+    }
+
+    await this.ensureBucketExists();
+  }
+
+  async ensureBucketExists(): Promise<void> {
+    try {
+      await this.client.send(
+        new HeadBucketCommand({ Bucket: this.config.bucket }),
+      );
+      this.logger.log(`Object storage bucket is ready: ${this.config.bucket}`);
+    } catch (error) {
+      if (isMissingBucketError(error)) {
+        await this.createBucket();
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  private async createBucket(): Promise<void> {
+    await this.client.send(
+      new CreateBucketCommand({ Bucket: this.config.bucket }),
+    );
+    this.logger.log(`Created object storage bucket: ${this.config.bucket}`);
+  }
+}
+
+function isMissingBucketError(error: unknown): boolean {
+  if (!isObject(error)) {
+    return false;
+  }
+
+  const errorDetails = error as {
+    name?: unknown;
+    $metadata?: { httpStatusCode?: unknown };
+  };
+
+  return (
+    errorDetails.$metadata?.httpStatusCode === 404 ||
+    (typeof errorDetails.name === 'string' &&
+      MISSING_BUCKET_ERROR_NAMES.includes(errorDetails.name))
+  );
+}
+
+const MISSING_BUCKET_ERROR_NAMES = [
+  'NotFound',
+  'NoSuchBucket',
+  'NotFoundError',
+];
+
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/backend/src/storage/storage.config.spec.ts
+++ b/apps/backend/src/storage/storage.config.spec.ts
@@ -1,0 +1,64 @@
+import {
+  buildObjectStorageConfig,
+  buildS3ClientConfig,
+} from './storage.config';
+
+describe('buildObjectStorageConfig', () => {
+  it('reads backend MinIO settings', () => {
+    const config = buildObjectStorageConfig((key) => {
+      const env: Record<string, string> = {
+        MINIO_BUCKET: 'backend-uploads',
+        MINIO_ENDPOINT: 'http://minio:9000',
+        MINIO_ROOT_USER: 'backend-access',
+        MINIO_ROOT_PASSWORD: 'backend-secret',
+      };
+
+      return env[key];
+    });
+
+    expect(config).toEqual({
+      bucket: 'backend-uploads',
+      endpoint: 'http://minio:9000',
+      accessKeyId: 'backend-access',
+      secretAccessKey: 'backend-secret',
+      createBucketOnStartup: true,
+    });
+  });
+
+  it('can use MinIO root credentials for local backend setup', () => {
+    const config = buildObjectStorageConfig((key) => {
+      const env: Record<string, string> = {
+        MINIO_BUCKET: 'umtas-uploads',
+        MINIO_ROOT_USER: 'storage-admin',
+        MINIO_ROOT_PASSWORD: 'storage-secret',
+      };
+
+      return env[key];
+    });
+
+    expect(config.accessKeyId).toBe('storage-admin');
+    expect(config.secretAccessKey).toBe('storage-secret');
+  });
+});
+
+describe('buildS3ClientConfig', () => {
+  it('builds an S3-compatible client config from storage config', () => {
+    const clientConfig = buildS3ClientConfig({
+      bucket: 'umtas-uploads',
+      endpoint: 'http://localhost:9000',
+      accessKeyId: 'minio',
+      secretAccessKey: 'miniosecret',
+      createBucketOnStartup: true,
+    });
+
+    expect(clientConfig).toEqual({
+      region: 'us-east-1',
+      endpoint: 'http://localhost:9000',
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: 'minio',
+        secretAccessKey: 'miniosecret',
+      },
+    });
+  });
+});

--- a/apps/backend/src/storage/storage.config.ts
+++ b/apps/backend/src/storage/storage.config.ts
@@ -1,4 +1,5 @@
 import type { S3ClientConfig } from '@aws-sdk/client-s3';
+import { z } from 'zod';
 
 export type EnvReader = (key: string) => string | undefined;
 
@@ -11,6 +12,11 @@ export interface ObjectStorageConfig {
 }
 
 const MINIO_SIGNING_REGION = 'us-east-1';
+const truthyStringSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .pipe(z.enum(['1', 'true', 'yes', 'on']));
 
 export function buildObjectStorageConfig(
   readEnv: EnvReader,
@@ -68,5 +74,5 @@ function readBoolean(value: string | undefined, fallback: boolean): boolean {
     return fallback;
   }
 
-  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+  return truthyStringSchema.safeParse(value).success;
 }

--- a/apps/backend/src/storage/storage.config.ts
+++ b/apps/backend/src/storage/storage.config.ts
@@ -1,0 +1,72 @@
+import type { S3ClientConfig } from '@aws-sdk/client-s3';
+
+export type EnvReader = (key: string) => string | undefined;
+
+export interface ObjectStorageConfig {
+  bucket: string;
+  endpoint?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  createBucketOnStartup: boolean;
+}
+
+const MINIO_SIGNING_REGION = 'us-east-1';
+
+export function buildObjectStorageConfig(
+  readEnv: EnvReader,
+): ObjectStorageConfig {
+  const config: ObjectStorageConfig = {
+    bucket: readEnv('MINIO_BUCKET') ?? '',
+    createBucketOnStartup: readBoolean(
+      readEnv('MINIO_CREATE_BUCKET_ON_STARTUP'),
+      true,
+    ),
+  };
+
+  const endpoint = readEnv('MINIO_ENDPOINT');
+  if (endpoint) {
+    config.endpoint = endpoint;
+  }
+
+  const accessKeyId = readEnv('MINIO_ROOT_USER');
+  if (accessKeyId) {
+    config.accessKeyId = accessKeyId;
+  }
+
+  const secretAccessKey = readEnv('MINIO_ROOT_PASSWORD');
+  if (secretAccessKey) {
+    config.secretAccessKey = secretAccessKey;
+  }
+
+  return config;
+}
+
+export function buildS3ClientConfig(
+  config: ObjectStorageConfig,
+): S3ClientConfig {
+  const clientConfig: S3ClientConfig = {
+    region: MINIO_SIGNING_REGION,
+    forcePathStyle: true,
+  };
+
+  if (config.endpoint) {
+    clientConfig.endpoint = config.endpoint;
+  }
+
+  if (config.accessKeyId || config.secretAccessKey) {
+    clientConfig.credentials = {
+      accessKeyId: config.accessKeyId ?? '',
+      secretAccessKey: config.secretAccessKey ?? '',
+    };
+  }
+
+  return clientConfig;
+}
+
+function readBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!value) {
+    return fallback;
+  }
+
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+}

--- a/apps/backend/src/storage/storage.module.ts
+++ b/apps/backend/src/storage/storage.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ObjectStorageService } from './object-storage.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [ObjectStorageService],
+  exports: [ObjectStorageService],
+})
+export class StorageModule {}


### PR DESCRIPTION
Split from #470.

## Summary
- Adds backend object storage configuration.
- Adds the S3-compatible object storage service and module.
- Wires backend package dependencies needed for storage.

## Review focus
- MinIO/S3 config parsing.
- Bucket creation and object IO behavior.
- Storage service test coverage.

## Notes
- Generated from origin/feat/queue-worker on top of origin/dev.
- Issue linking intentionally left for a later step.
