### PR TITLE
Add backend queue and job handling

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -28,6 +28,7 @@
     "docker:clean": "docker-compose down -v && docker network prune -f"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.940.0",
     "@better-auth/redis-storage": "^1.6.11",
     "@electric-sql/pglite": "^0.4.5",
     "@nestjs/axios": "^4.0.1",

--- a/apps/backend/src/db/database.constants.ts
+++ b/apps/backend/src/db/database.constants.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export const DB_MODES = {
   PGLITE: 'PGLITE',
   DATABASE: 'DATABASE',
@@ -5,11 +7,23 @@ export const DB_MODES = {
 
 export type DbMode = (typeof DB_MODES)[keyof typeof DB_MODES];
 
-export function parseDbMode(value: string | undefined): DbMode {
-  const normalized = (value ?? DB_MODES.DATABASE).trim().toUpperCase();
+const dbModeSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .pipe(z.enum([DB_MODES.PGLITE, DB_MODES.DATABASE]));
 
-  if (normalized === DB_MODES.PGLITE || normalized === DB_MODES.DATABASE) {
-    return normalized;
+const seedFlagSchema = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .pipe(z.enum(['TRUE', 'FALSE', '']));
+
+export function parseDbMode(value: string | undefined): DbMode {
+  const result = dbModeSchema.safeParse(value ?? DB_MODES.DATABASE);
+
+  if (result.success) {
+    return result.data;
   }
 
   throw new Error(
@@ -18,15 +32,11 @@ export function parseDbMode(value: string | undefined): DbMode {
 }
 
 export function parseSeedFlag(value: string | undefined): boolean {
-  const normalized = (value ?? 'FALSE').trim().toUpperCase();
+  const result = seedFlagSchema.safeParse(value ?? 'FALSE');
 
-  if (normalized === 'TRUE') {
-    return true;
+  if (!result.success) {
+    throw new Error(`Invalid SEED: ${String(value)}. Expected TRUE or FALSE`);
   }
 
-  if (normalized === 'FALSE' || normalized.length === 0) {
-    return false;
-  }
-
-  throw new Error(`Invalid SEED: ${String(value)}. Expected TRUE or FALSE`);
+  return result.data === 'TRUE';
 }

--- a/apps/backend/src/jobs/dto/pdf-parse-job.dto.ts
+++ b/apps/backend/src/jobs/dto/pdf-parse-job.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+import type { PdfParseJobData } from 'shared-types';
+
+export class PdfParseJobDto implements PdfParseJobData {
+  @ApiProperty({ example: 'parse-job-123' })
+  @IsString()
+  @IsNotEmpty()
+  jobId!: string;
+
+  @ApiProperty({ example: 'uploads/timetables/parse-job-123.pdf' })
+  @IsString()
+  @IsNotEmpty()
+  fileKey!: string;
+
+  @ApiProperty({ example: 'up' })
+  @IsString()
+  @IsNotEmpty()
+  adapterKey!: string;
+}

--- a/apps/backend/src/jobs/dto/timetable-solve-job.dto.ts
+++ b/apps/backend/src/jobs/dto/timetable-solve-job.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+import type { TimetableSolveJobData } from 'shared-types';
+
+export class TimetableSolveJobDto implements TimetableSolveJobData {
+  @ApiProperty({ example: 'solve-job-123' })
+  @IsString()
+  @IsNotEmpty()
+  jobId!: string;
+
+  @ApiProperty({ example: 'default' })
+  @IsString()
+  @IsNotEmpty()
+  solverKey!: string;
+
+  @ApiProperty({ enum: ['feasibility', 'optimization'] })
+  @IsIn(['feasibility', 'optimization'])
+  mode!: 'feasibility' | 'optimization';
+}

--- a/apps/backend/src/jobs/jobs.module.ts
+++ b/apps/backend/src/jobs/jobs.module.ts
@@ -1,0 +1,84 @@
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import {
+  BACKEND_QUEUE_CONFIG,
+  PDF_PARSE_QUEUE_TOKEN,
+  TIMETABLE_SOLVE_QUEUE_TOKEN,
+} from './queue.constants';
+import {
+  BackendQueueConfig,
+  buildBullRootOptions,
+  buildQueueConfig,
+} from './queue.config';
+import { QueueProducerService } from './queue-producer.service';
+import { WorkerCallbackAuthGuard } from './worker-callback-auth.guard';
+
+const queueConfigProvider = {
+  provide: BACKEND_QUEUE_CONFIG,
+  inject: [ConfigService],
+  useFactory: buildBackendQueueConfig,
+};
+
+function buildBackendQueueConfig(
+  configService: ConfigService,
+): BackendQueueConfig {
+  return buildQueueConfig((key) => configService.get<string>(key));
+}
+
+function buildBullRootOptionsFromConfigService(configService: ConfigService) {
+  const config = buildBackendQueueConfig(configService);
+  return buildBullRootOptions(config);
+}
+
+function buildPdfParseQueueOptions(configService: ConfigService) {
+  const config = buildBackendQueueConfig(configService);
+  return {
+    name: config.pdfParse.name,
+    defaultJobOptions: config.pdfParse.defaultJobOptions,
+  };
+}
+
+function buildTimetableSolveQueueOptions(configService: ConfigService) {
+  const config = buildBackendQueueConfig(configService);
+  return {
+    name: config.timetableSolve.name,
+    defaultJobOptions: config.timetableSolve.defaultJobOptions,
+  };
+}
+
+@Module({
+  imports: [
+    ConfigModule,
+    BullModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: buildBullRootOptionsFromConfigService,
+    }),
+    BullModule.registerQueueAsync(
+      {
+        name: PDF_PARSE_QUEUE_TOKEN,
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: buildPdfParseQueueOptions,
+      },
+      {
+        name: TIMETABLE_SOLVE_QUEUE_TOKEN,
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: buildTimetableSolveQueueOptions,
+      },
+    ),
+  ],
+  providers: [
+    queueConfigProvider,
+    QueueProducerService,
+    WorkerCallbackAuthGuard,
+  ],
+  exports: [
+    BACKEND_QUEUE_CONFIG,
+    QueueProducerService,
+    WorkerCallbackAuthGuard,
+  ],
+})
+export class JobsModule {}

--- a/apps/backend/src/jobs/queue-producer.service.spec.ts
+++ b/apps/backend/src/jobs/queue-producer.service.spec.ts
@@ -1,0 +1,58 @@
+import type { Queue } from 'bullmq';
+import type { PdfParseJobData, TimetableSolveJobData } from 'shared-types';
+import { QueueProducerService } from './queue-producer.service';
+import {
+  PDF_PARSE_JOB_NAME,
+  TIMETABLE_SOLVE_JOB_NAME,
+} from './queue.constants';
+
+describe('QueueProducerService', () => {
+  const pdfParseAdd = jest.fn();
+  const timetableSolveAdd = jest.fn();
+
+  const pdfParseQueue = {
+    add: pdfParseAdd,
+  } as unknown as jest.Mocked<Queue<PdfParseJobData>>;
+  const timetableSolveQueue = {
+    add: timetableSolveAdd,
+  } as unknown as jest.Mocked<Queue<TimetableSolveJobData>>;
+
+  let service: QueueProducerService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    pdfParseAdd.mockResolvedValue(undefined);
+    timetableSolveAdd.mockResolvedValue(undefined);
+    service = new QueueProducerService(pdfParseQueue, timetableSolveQueue);
+  });
+
+  it('enqueues PDF parse payloads with the backend job id as BullMQ jobId', async () => {
+    const payload: PdfParseJobData = {
+      jobId: 'parse-1',
+      fileKey: 'uploads/parse-1.pdf',
+      adapterKey: 'up',
+    };
+
+    await service.enqueuePdfParseJob(payload);
+
+    expect(pdfParseAdd).toHaveBeenCalledWith(PDF_PARSE_JOB_NAME, payload, {
+      jobId: 'parse-1',
+    });
+  });
+
+  it('enqueues timetable solve payloads with the backend job id as BullMQ jobId', async () => {
+    const payload: TimetableSolveJobData = {
+      jobId: 'solve-1',
+      solverKey: 'default',
+      mode: 'feasibility',
+    };
+
+    await service.enqueueTimetableSolveJob(payload);
+
+    expect(timetableSolveAdd).toHaveBeenCalledWith(
+      TIMETABLE_SOLVE_JOB_NAME,
+      payload,
+      { jobId: 'solve-1' },
+    );
+  });
+});

--- a/apps/backend/src/jobs/queue-producer.service.spec.ts
+++ b/apps/backend/src/jobs/queue-producer.service.spec.ts
@@ -26,7 +26,7 @@ describe('QueueProducerService', () => {
     service = new QueueProducerService(pdfParseQueue, timetableSolveQueue);
   });
 
-  it('enqueues PDF parse payloads with the backend job id as BullMQ jobId', async () => {
+  it('enqueues PDF parse payloads without using the backend job id as BullMQ jobId', async () => {
     const payload: PdfParseJobData = {
       jobId: 'parse-1',
       fileKey: 'uploads/parse-1.pdf',
@@ -35,9 +35,7 @@ describe('QueueProducerService', () => {
 
     await service.enqueuePdfParseJob(payload);
 
-    expect(pdfParseAdd).toHaveBeenCalledWith(PDF_PARSE_JOB_NAME, payload, {
-      jobId: 'parse-1',
-    });
+    expect(pdfParseAdd).toHaveBeenCalledWith(PDF_PARSE_JOB_NAME, payload);
   });
 
   it('enqueues timetable solve payloads with the backend job id as BullMQ jobId', async () => {

--- a/apps/backend/src/jobs/queue-producer.service.ts
+++ b/apps/backend/src/jobs/queue-producer.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import type { Job, Queue } from 'bullmq';
+import type { PdfParseJobData, TimetableSolveJobData } from 'shared-types';
+import {
+  PDF_PARSE_JOB_NAME,
+  PDF_PARSE_QUEUE_TOKEN,
+  TIMETABLE_SOLVE_JOB_NAME,
+  TIMETABLE_SOLVE_QUEUE_TOKEN,
+} from './queue.constants';
+
+@Injectable()
+export class QueueProducerService {
+  constructor(
+    @InjectQueue(PDF_PARSE_QUEUE_TOKEN)
+    private readonly pdfParseQueue: Queue<PdfParseJobData>,
+    @InjectQueue(TIMETABLE_SOLVE_QUEUE_TOKEN)
+    private readonly timetableSolveQueue: Queue<TimetableSolveJobData>,
+  ) {}
+
+  enqueuePdfParseJob(data: PdfParseJobData): Promise<Job<PdfParseJobData>> {
+    return this.pdfParseQueue.add(PDF_PARSE_JOB_NAME, data, {
+      jobId: data.jobId,
+    });
+  }
+
+  enqueueTimetableSolveJob(
+    data: TimetableSolveJobData,
+  ): Promise<Job<TimetableSolveJobData>> {
+    return this.timetableSolveQueue.add(TIMETABLE_SOLVE_JOB_NAME, data, {
+      jobId: data.jobId,
+    });
+  }
+}

--- a/apps/backend/src/jobs/queue-producer.service.ts
+++ b/apps/backend/src/jobs/queue-producer.service.ts
@@ -19,9 +19,7 @@ export class QueueProducerService {
   ) {}
 
   enqueuePdfParseJob(data: PdfParseJobData): Promise<Job<PdfParseJobData>> {
-    return this.pdfParseQueue.add(PDF_PARSE_JOB_NAME, data, {
-      jobId: data.jobId,
-    });
+    return this.pdfParseQueue.add(PDF_PARSE_JOB_NAME, data);
   }
 
   enqueueTimetableSolveJob(

--- a/apps/backend/src/jobs/queue.config.spec.ts
+++ b/apps/backend/src/jobs/queue.config.spec.ts
@@ -1,0 +1,56 @@
+import { buildQueueConfig } from './queue.config';
+
+describe('buildQueueConfig', () => {
+  it('uses configured queue names and job options', () => {
+    const env = new Map<string, string>([
+      ['BULLMQ_REDIS_URL', 'redis://user:pass@redis.internal:6380/2'],
+      ['PDF_PARSE_QUEUE_NAME', 'custom.pdf'],
+      ['PDF_PARSE_ATTEMPTS', '4'],
+      ['PDF_PARSE_BACKOFF_DELAY_MS', '7000'],
+      ['TIMETABLE_SOLVE_QUEUE_NAME', 'custom.solve'],
+      ['TIMETABLE_SOLVE_ATTEMPTS', '5'],
+      ['TIMETABLE_SOLVE_BACKOFF_DELAY_MS', '12000'],
+    ]);
+
+    const config = buildQueueConfig((key) => env.get(key));
+
+    expect(config.connection).toMatchObject({
+      host: 'redis.internal',
+      port: 6380,
+      username: 'user',
+      password: 'pass',
+      db: 2,
+      maxRetriesPerRequest: null,
+    });
+    expect(config.pdfParse.name).toBe('custom.pdf');
+    expect(config.pdfParse.defaultJobOptions).toMatchObject({
+      attempts: 4,
+      backoff: { type: 'exponential', delay: 7000 },
+    });
+    expect(config.timetableSolve.name).toBe('custom.solve');
+    expect(config.timetableSolve.defaultJobOptions).toMatchObject({
+      attempts: 5,
+      backoff: { type: 'exponential', delay: 12000 },
+    });
+  });
+
+  it('falls back to phase 1 defaults', () => {
+    const config = buildQueueConfig(() => undefined);
+
+    expect(config.connection).toMatchObject({
+      host: 'localhost',
+      port: 6379,
+      maxRetriesPerRequest: null,
+    });
+    expect(config.pdfParse.name).toBe('pdf.parse');
+    expect(config.pdfParse.defaultJobOptions).toMatchObject({
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5000 },
+    });
+    expect(config.timetableSolve.name).toBe('timetable.solve');
+    expect(config.timetableSolve.defaultJobOptions).toMatchObject({
+      attempts: 2,
+      backoff: { type: 'exponential', delay: 10000 },
+    });
+  });
+});

--- a/apps/backend/src/jobs/queue.config.ts
+++ b/apps/backend/src/jobs/queue.config.ts
@@ -1,0 +1,158 @@
+import { find, isString } from 'lodash';
+import type { JobsOptions, QueueOptions } from 'bullmq';
+import type { RedisOptions } from 'ioredis';
+import { z } from 'zod';
+
+export interface QueueRuntimeConfig {
+  name: string;
+  defaultJobOptions: JobsOptions;
+}
+
+export interface BackendQueueConfig {
+  connection: RedisOptions;
+  pdfParse: QueueRuntimeConfig;
+  timetableSolve: QueueRuntimeConfig;
+}
+
+export type EnvReader = (key: string) => string | undefined;
+
+interface QueueEnvConfig {
+  nameEnvKey: string;
+  defaultName: string;
+  attemptsEnvKey: string;
+  defaultAttempts: number;
+  backoffDelayEnvKey: string;
+  defaultBackoffDelayMs: number;
+}
+
+const DEFAULT_REDIS_URL = 'redis://localhost:6379';
+const DEFAULT_REDIS_PORT = 6379;
+const ONE_DAY_SECONDS = 86_400;
+const ONE_WEEK_SECONDS = 604_800;
+const COMPLETED_JOB_LIMIT = 1_000;
+const FAILED_JOB_LIMIT = 5_000;
+const positiveIntSchema = z.coerce.number().int().positive();
+
+const pdfParseQueueEnvConfig: QueueEnvConfig = {
+  nameEnvKey: 'PDF_PARSE_QUEUE_NAME',
+  defaultName: 'pdf.parse',
+  attemptsEnvKey: 'PDF_PARSE_ATTEMPTS',
+  defaultAttempts: 3,
+  backoffDelayEnvKey: 'PDF_PARSE_BACKOFF_DELAY_MS',
+  defaultBackoffDelayMs: 5_000,
+};
+
+const timetableSolveQueueEnvConfig: QueueEnvConfig = {
+  nameEnvKey: 'TIMETABLE_SOLVE_QUEUE_NAME',
+  defaultName: 'timetable.solve',
+  attemptsEnvKey: 'TIMETABLE_SOLVE_ATTEMPTS',
+  defaultAttempts: 2,
+  backoffDelayEnvKey: 'TIMETABLE_SOLVE_BACKOFF_DELAY_MS',
+  defaultBackoffDelayMs: 10_000,
+};
+
+export function buildQueueConfig(readEnv: EnvReader): BackendQueueConfig {
+  const redisUrl = readFirstConfiguredValue(
+    readEnv,
+    ['BULLMQ_REDIS_URL', 'REDIS_URL'],
+    DEFAULT_REDIS_URL,
+  );
+
+  return {
+    connection: parseRedisUrl(redisUrl),
+    pdfParse: buildQueueRuntimeConfig(readEnv, pdfParseQueueEnvConfig),
+    timetableSolve: buildQueueRuntimeConfig(
+      readEnv,
+      timetableSolveQueueEnvConfig,
+    ),
+  };
+}
+
+export function buildBullRootOptions(config: BackendQueueConfig): QueueOptions {
+  return {
+    connection: config.connection,
+  };
+}
+
+function parseRedisUrl(redisUrl: string): RedisOptions {
+  const url = new URL(redisUrl);
+  const db = url.pathname.replace('/', '');
+
+  const config: RedisOptions = {
+    host: url.hostname,
+    port: url.port ? Number(url.port) : DEFAULT_REDIS_PORT,
+    maxRetriesPerRequest: null,
+  };
+
+  if (url.username) {
+    config.username = decodeURIComponent(url.username);
+  }
+
+  if (url.password) {
+    config.password = decodeURIComponent(url.password);
+  }
+
+  if (db) {
+    config.db = Number(db);
+  }
+
+  if (url.protocol === 'rediss:') {
+    config.tls = {};
+  }
+
+  return config;
+}
+
+function buildQueueRuntimeConfig(
+  readEnv: EnvReader,
+  queueEnvConfig: QueueEnvConfig,
+): QueueRuntimeConfig {
+  const attempts = readPositiveInt(
+    readEnv(queueEnvConfig.attemptsEnvKey),
+    queueEnvConfig.defaultAttempts,
+  );
+  const backoffDelay = readPositiveInt(
+    readEnv(queueEnvConfig.backoffDelayEnvKey),
+    queueEnvConfig.defaultBackoffDelayMs,
+  );
+
+  return {
+    name: readEnv(queueEnvConfig.nameEnvKey) ?? queueEnvConfig.defaultName,
+    defaultJobOptions: buildDefaultJobOptions(attempts, backoffDelay),
+  };
+}
+
+function buildDefaultJobOptions(
+  attempts: number,
+  backoffDelay: number,
+): JobsOptions {
+  return {
+    attempts,
+    backoff: {
+      type: 'exponential',
+      delay: backoffDelay,
+    },
+    removeOnComplete: {
+      age: ONE_DAY_SECONDS,
+      count: COMPLETED_JOB_LIMIT,
+    },
+    removeOnFail: {
+      age: ONE_WEEK_SECONDS,
+      count: FAILED_JOB_LIMIT,
+    },
+  };
+}
+
+function readFirstConfiguredValue(
+  readEnv: EnvReader,
+  keys: string[],
+  fallback: string,
+): string {
+  const values = keys.map((key) => readEnv(key));
+  return find(values, isString) ?? fallback;
+}
+
+function readPositiveInt(value: string | undefined, fallback: number): number {
+  const result = positiveIntSchema.safeParse(value);
+  return result.success ? result.data : fallback;
+}

--- a/apps/backend/src/jobs/queue.config.ts
+++ b/apps/backend/src/jobs/queue.config.ts
@@ -1,4 +1,3 @@
-import { find, isString } from 'lodash';
 import type { JobsOptions, QueueOptions } from 'bullmq';
 import type { RedisOptions } from 'ioredis';
 import { z } from 'zod';
@@ -148,8 +147,14 @@ function readFirstConfiguredValue(
   keys: string[],
   fallback: string,
 ): string {
-  const values = keys.map((key) => readEnv(key));
-  return find(values, isString) ?? fallback;
+  for (const key of keys) {
+    const value = readEnv(key);
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return fallback;
 }
 
 function readPositiveInt(value: string | undefined, fallback: number): number {

--- a/apps/backend/src/jobs/queue.constants.ts
+++ b/apps/backend/src/jobs/queue.constants.ts
@@ -1,0 +1,7 @@
+export const PDF_PARSE_QUEUE_TOKEN = 'pdf.parse';
+export const TIMETABLE_SOLVE_QUEUE_TOKEN = 'timetable.solve';
+
+export const PDF_PARSE_JOB_NAME = 'parse-pdf';
+export const TIMETABLE_SOLVE_JOB_NAME = 'solve-timetable';
+
+export const BACKEND_QUEUE_CONFIG = Symbol('BACKEND_QUEUE_CONFIG');

--- a/apps/backend/src/jobs/worker-callback-auth.guard.spec.ts
+++ b/apps/backend/src/jobs/worker-callback-auth.guard.spec.ts
@@ -1,0 +1,53 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  WorkerCallbackAuthGuard,
+  extractBearerToken,
+  isValidWorkerCallbackAuth,
+} from './worker-callback-auth.guard';
+
+describe('worker callback auth helpers', () => {
+  it('extracts bearer tokens', () => {
+    expect(extractBearerToken('Bearer secret')).toBe('secret');
+    expect(extractBearerToken('Basic secret')).toBeNull();
+    expect(extractBearerToken(undefined)).toBeNull();
+  });
+
+  it('validates the configured callback token', () => {
+    expect(isValidWorkerCallbackAuth('Bearer secret', 'secret')).toBe(true);
+    expect(isValidWorkerCallbackAuth('Bearer wrong', 'secret')).toBe(false);
+    expect(isValidWorkerCallbackAuth('Bearer secret', undefined)).toBe(false);
+  });
+});
+
+describe('WorkerCallbackAuthGuard', () => {
+  it('allows requests with the configured bearer token', () => {
+    const guard = new WorkerCallbackAuthGuard({
+      get: jest.fn().mockReturnValue('secret'),
+    } as unknown as ConfigService);
+
+    expect(guard.canActivate(contextWithAuthorization('Bearer secret'))).toBe(
+      true,
+    );
+  });
+
+  it('rejects requests with a missing or invalid token', () => {
+    const guard = new WorkerCallbackAuthGuard({
+      get: jest.fn().mockReturnValue('secret'),
+    } as unknown as ConfigService);
+
+    expect(() =>
+      guard.canActivate(contextWithAuthorization('Bearer wrong')),
+    ).toThrow(UnauthorizedException);
+  });
+});
+
+function contextWithAuthorization(authorization?: string): ExecutionContext {
+  return {
+    switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn().mockReturnValue({
+        headers: { authorization },
+      }),
+    }),
+  } as unknown as ExecutionContext;
+}

--- a/apps/backend/src/jobs/worker-callback-auth.guard.ts
+++ b/apps/backend/src/jobs/worker-callback-auth.guard.ts
@@ -1,0 +1,59 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { isString } from 'lodash';
+import type { IncomingHttpHeaders } from 'node:http';
+
+const BEARER_AUTH_SCHEME = 'Bearer';
+
+export function extractBearerToken(
+  authorization: IncomingHttpHeaders['authorization'],
+): string | null {
+  if (!isString(authorization)) {
+    return null;
+  }
+
+  const authParts = authorization.split(' ');
+  const scheme = authParts[0];
+  const token = authParts[1];
+
+  if (scheme !== BEARER_AUTH_SCHEME || !token) {
+    return null;
+  }
+
+  return token;
+}
+
+export function isValidWorkerCallbackAuth(
+  authorization: IncomingHttpHeaders['authorization'],
+  expectedToken: string | undefined,
+): boolean {
+  const token = extractBearerToken(authorization);
+  return Boolean(expectedToken && token && token === expectedToken);
+}
+
+@Injectable()
+export class WorkerCallbackAuthGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{
+      headers: IncomingHttpHeaders;
+    }>();
+
+    const expectedToken = this.configService.get<string>(
+      'WORKER_CALLBACK_TOKEN',
+    );
+    if (
+      !isValidWorkerCallbackAuth(request.headers.authorization, expectedToken)
+    ) {
+      throw new UnauthorizedException('Invalid worker callback token');
+    }
+
+    return true;
+  }
+}

--- a/apps/backend/src/solver/dto/solver-callback.dto.ts
+++ b/apps/backend/src/solver/dto/solver-callback.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsObject, IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import type { SolverCallbackPayload } from 'shared-types';
+import { WorkerCallbackErrorDto } from '../../pdf-parser/dto/pdf-parser-callback.dto';
+
+export class SolverCallbackDto implements SolverCallbackPayload {
+  @ApiProperty({ enum: ['completed', 'failed'] })
+  @IsIn(['completed', 'failed'])
+  status!: 'completed' | 'failed';
+
+  @ApiPropertyOptional({
+    type: 'object',
+    additionalProperties: true,
+    description: 'TODO: replace with the final solver output contract.',
+  })
+  @IsOptional()
+  @IsObject()
+  result?: Record<string, unknown>;
+
+  @ApiPropertyOptional({ type: () => WorkerCallbackErrorDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => WorkerCallbackErrorDto)
+  error?: WorkerCallbackErrorDto;
+}

--- a/apps/backend/src/solver/dto/solver-callback.dto.ts
+++ b/apps/backend/src/solver/dto/solver-callback.dto.ts
@@ -12,7 +12,8 @@ export class SolverCallbackDto implements SolverCallbackPayload {
   @ApiPropertyOptional({
     type: 'object',
     additionalProperties: true,
-    description: 'TODO: replace with the final solver output contract.',
+    description:
+      'Temporary payload shape until the solver output contract is final.',
   })
   @IsOptional()
   @IsObject()

--- a/apps/backend/src/solver/solver.controller.ts
+++ b/apps/backend/src/solver/solver.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotImplementedException,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Public } from '../auth/auth.guard';
+import { WorkerCallbackAuthGuard } from '../jobs/worker-callback-auth.guard';
+import { SolverCallbackDto } from './dto/solver-callback.dto';
+
+@Public()
+@ApiTags('Solver')
+@ApiBearerAuth('bearer')
+@UseGuards(WorkerCallbackAuthGuard)
+@Controller('solver')
+export class SolverController {
+  @Get('jobs/:jobId/input')
+  getInput(@Param('jobId') _jobId: string) {
+    // TODO: return backend-prepared solver input JSON once the solver input
+    // builder is implemented.
+    throw new NotImplementedException(
+      'Solver input builder is not implemented',
+    );
+  }
+
+  @Post('jobs/:jobId/callback')
+  @HttpCode(HttpStatus.ACCEPTED)
+  receiveCallback(
+    @Param('jobId') jobId: string,
+    @Body() _body: SolverCallbackDto,
+  ) {
+    // TODO: persist solver status/result after the solver CLI contract settles.
+    return { accepted: true, jobId };
+  }
+}

--- a/apps/backend/src/solver/solver.controller.ts
+++ b/apps/backend/src/solver/solver.controller.ts
@@ -22,7 +22,7 @@ import { SolverCallbackDto } from './dto/solver-callback.dto';
 export class SolverController {
   @Get('jobs/:jobId/input')
   getInput(@Param('jobId') _jobId: string) {
-    // TODO: return backend-prepared solver input JSON once the solver input
+    // Future work: return backend-prepared solver input JSON once the solver input
     // builder is implemented.
     throw new NotImplementedException(
       'Solver input builder is not implemented',
@@ -33,9 +33,10 @@ export class SolverController {
   @HttpCode(HttpStatus.ACCEPTED)
   receiveCallback(
     @Param('jobId') jobId: string,
-    @Body() _body: SolverCallbackDto,
+    @Body() body: SolverCallbackDto,
   ) {
-    // TODO: persist solver status/result after the solver CLI contract settles.
+    // Future work: persist solver status/result after the solver CLI contract settles.
+    void body;
     return { accepted: true, jobId };
   }
 }

--- a/apps/backend/src/solver/solver.module.ts
+++ b/apps/backend/src/solver/solver.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { JobsModule } from '../jobs/jobs.module';
+import { SolverController } from './solver.controller';
+
+@Module({
+  imports: [JobsModule],
+  controllers: [SolverController],
+})
+export class SolverModule {}


### PR DESCRIPTION
Split from #470.

## Summary
- Adds backend BullMQ queue configuration.
- Adds queue producer, job DTOs, jobs module, and worker callback guard.
- Adds the solver callback placeholder used by queued worker jobs.

## Review focus
- Queue defaults and Redis parsing.
- Job payload contracts.
- Worker callback authentication.

## Notes
- Generated from origin/feat/queue-worker on top of origin/dev.
- Issue linking intentionally left for a later step.
