### PR TITLE
Add backend PDF parser API

### DIFF
--- a/apps/backend/drizzle/0005_clean_iceman.sql
+++ b/apps/backend/drizzle/0005_clean_iceman.sql
@@ -1,0 +1,38 @@
+CREATE TABLE "PARSE_JOB" (
+	"JobID" uuid PRIMARY KEY NOT NULL,
+	"UserID" uuid NOT NULL,
+	"UniversityID" uuid NOT NULL,
+	"AdapterKey" varchar(64) NOT NULL,
+	"FileKey" text,
+	"ClientPdfStreamHash" varchar(64),
+	"PdfStreamHash" varchar(64) NOT NULL,
+	"FingerprintAlgorithm" varchar(128) NOT NULL,
+	"StreamCount" integer NOT NULL,
+	"GroupID" uuid,
+	"Status" varchar(32) DEFAULT 'queued' NOT NULL,
+	"Result" jsonb,
+	"ErrorCode" varchar(128),
+	"ErrorMessage" text,
+	"ErrorDetails" jsonb,
+	"CreatedAt" timestamp with time zone DEFAULT now() NOT NULL,
+	"UpdatedAt" timestamp with time zone DEFAULT now() NOT NULL,
+	"CompletedAt" timestamp with time zone,
+	"FailedAt" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "Event" ADD COLUMN "validated" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "Event" ADD COLUMN "ImportKey" varchar(64);--> statement-breakpoint
+ALTER TABLE "Modules" ADD COLUMN "validated" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "PARSE_JOB" ADD CONSTRAINT "PARSE_JOB_UserID_user_id_fk" FOREIGN KEY ("UserID") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "PARSE_JOB" ADD CONSTRAINT "PARSE_JOB_UniversityID_University_UniversityID_fk" FOREIGN KEY ("UniversityID") REFERENCES "public"."University"("UniversityID") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "PARSE_JOB" ADD CONSTRAINT "PARSE_JOB_GroupID_ModuleGrouping_GroupID_fk" FOREIGN KEY ("GroupID") REFERENCES "public"."ModuleGrouping"("GroupID") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "parse_job_user_id_idx" ON "PARSE_JOB" USING btree ("UserID");--> statement-breakpoint
+CREATE INDEX "parse_job_status_idx" ON "PARSE_JOB" USING btree ("Status");--> statement-breakpoint
+CREATE INDEX "parse_job_group_id_idx" ON "PARSE_JOB" USING btree ("GroupID");--> statement-breakpoint
+CREATE INDEX "parse_job_created_at_idx" ON "PARSE_JOB" USING btree ("CreatedAt");--> statement-breakpoint
+CREATE UNIQUE INDEX "parse_job_duplicate_unique" ON "PARSE_JOB" USING btree ("UserID","UniversityID","AdapterKey","FingerprintAlgorithm","PdfStreamHash");--> statement-breakpoint
+CREATE UNIQUE INDEX "event_import_key_unique" ON "Event" USING btree ("ImportKey");--> statement-breakpoint
+CREATE UNIQUE INDEX "university_event_module_event_unique" ON "UniversityEvent" USING btree ("moduleID","eventID");--> statement-breakpoint
+CREATE UNIQUE INDEX "modules_module_code_unique" ON "Modules" USING btree ("moduleCode");--> statement-breakpoint
+CREATE UNIQUE INDEX "group_modules_group_module_unique" ON "GroupModules" USING btree ("GroupID","ModuleID");--> statement-breakpoint
+CREATE UNIQUE INDEX "venue_university_name_unique" ON "Venue" USING btree ("UniversityID","VenueName");

--- a/apps/backend/drizzle/meta/0005_snapshot.json
+++ b/apps/backend/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1970 @@
+{
+  "id": "5947f1d1-1e1b-411d-b341-4e5d8d615822",
+  "prevId": "40821212-da43-4d12-a359-511b579f2b42",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            {
+              "expression": "providerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "accountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rateLimit": {
+      "name": "rateLimit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_key_unique": {
+          "name": "rate_limit_key_unique",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonatedBy": {
+          "name": "impersonatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_expires_at_idx": {
+          "name": "session_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["userId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_role_idx": {
+          "name": "user_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_expires_at_idx": {
+          "name": "verification_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Event": {
+      "name": "Event",
+      "schema": "",
+      "columns": {
+        "eventID": {
+          "name": "eventID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "eventName": {
+          "name": "eventName",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventCode": {
+          "name": "eventCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventCriteria": {
+          "name": "eventCriteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isRecurring": {
+          "name": "isRecurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "validated": {
+          "name": "validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ImportKey": {
+          "name": "ImportKey",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_import_key_unique": {
+          "name": "event_import_key_unique",
+          "columns": [
+            {
+              "expression": "ImportKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EventAttendance": {
+      "name": "EventAttendance",
+      "schema": "",
+      "columns": {
+        "attendanceID": {
+          "name": "attendanceID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "eventID": {
+          "name": "eventID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "UserID": {
+          "name": "UserID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventDate": {
+          "name": "eventDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "AttendanceState",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_ATTENDING'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "EventAttendance_eventID_Event_eventID_fk": {
+          "name": "EventAttendance_eventID_Event_eventID_fk",
+          "tableFrom": "EventAttendance",
+          "tableTo": "Event",
+          "columnsFrom": ["eventID"],
+          "columnsTo": ["eventID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "EventAttendance_UserID_user_id_fk": {
+          "name": "EventAttendance_UserID_user_id_fk",
+          "tableFrom": "EventAttendance",
+          "tableTo": "user",
+          "columnsFrom": ["UserID"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PersonalEvent": {
+      "name": "PersonalEvent",
+      "schema": "",
+      "columns": {
+        "PersonalEventID": {
+          "name": "PersonalEventID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "UserID": {
+          "name": "UserID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventID": {
+          "name": "eventID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "PersonalEvent_UserID_user_id_fk": {
+          "name": "PersonalEvent_UserID_user_id_fk",
+          "tableFrom": "PersonalEvent",
+          "tableTo": "user",
+          "columnsFrom": ["UserID"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "PersonalEvent_eventID_Event_eventID_fk": {
+          "name": "PersonalEvent_eventID_Event_eventID_fk",
+          "tableFrom": "PersonalEvent",
+          "tableTo": "Event",
+          "columnsFrom": ["eventID"],
+          "columnsTo": ["eventID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UniversityEvent": {
+      "name": "UniversityEvent",
+      "schema": "",
+      "columns": {
+        "universityEventID": {
+          "name": "universityEventID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "moduleID": {
+          "name": "moduleID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventID": {
+          "name": "eventID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "VenueID": {
+          "name": "VenueID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "university_event_module_event_unique": {
+          "name": "university_event_module_event_unique",
+          "columns": [
+            {
+              "expression": "moduleID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UniversityEvent_moduleID_Modules_moduleID_fk": {
+          "name": "UniversityEvent_moduleID_Modules_moduleID_fk",
+          "tableFrom": "UniversityEvent",
+          "tableTo": "Modules",
+          "columnsFrom": ["moduleID"],
+          "columnsTo": ["moduleID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "UniversityEvent_eventID_Event_eventID_fk": {
+          "name": "UniversityEvent_eventID_Event_eventID_fk",
+          "tableFrom": "UniversityEvent",
+          "tableTo": "Event",
+          "columnsFrom": ["eventID"],
+          "columnsTo": ["eventID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "UniversityEvent_VenueID_Venue_VenueID_fk": {
+          "name": "UniversityEvent_VenueID_Venue_VenueID_fk",
+          "tableFrom": "UniversityEvent",
+          "tableTo": "Venue",
+          "columnsFrom": ["VenueID"],
+          "columnsTo": ["VenueID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModuleEnrollment": {
+      "name": "ModuleEnrollment",
+      "schema": "",
+      "columns": {
+        "ModuleID": {
+          "name": "ModuleID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "UserID": {
+          "name": "UserID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ModuleEnrollment_ModuleID_Modules_moduleID_fk": {
+          "name": "ModuleEnrollment_ModuleID_Modules_moduleID_fk",
+          "tableFrom": "ModuleEnrollment",
+          "tableTo": "Modules",
+          "columnsFrom": ["ModuleID"],
+          "columnsTo": ["moduleID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ModuleEnrollment_UserID_user_id_fk": {
+          "name": "ModuleEnrollment_UserID_user_id_fk",
+          "tableFrom": "ModuleEnrollment",
+          "tableTo": "user",
+          "columnsFrom": ["UserID"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ModuleEnrollment_ModuleID_UserID_pk": {
+          "name": "ModuleEnrollment_ModuleID_UserID_pk",
+          "columns": ["ModuleID", "UserID"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModuleStyling": {
+      "name": "ModuleStyling",
+      "schema": "",
+      "columns": {
+        "ModuleID": {
+          "name": "ModuleID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "UserID": {
+          "name": "UserID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "styling": {
+          "name": "styling",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"colour\":\"\"}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ModuleStyling_ModuleID_Modules_moduleID_fk": {
+          "name": "ModuleStyling_ModuleID_Modules_moduleID_fk",
+          "tableFrom": "ModuleStyling",
+          "tableTo": "Modules",
+          "columnsFrom": ["ModuleID"],
+          "columnsTo": ["moduleID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ModuleStyling_UserID_user_id_fk": {
+          "name": "ModuleStyling_UserID_user_id_fk",
+          "tableFrom": "ModuleStyling",
+          "tableTo": "user",
+          "columnsFrom": ["UserID"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ModuleStyling_ModuleID_UserID_pk": {
+          "name": "ModuleStyling_ModuleID_UserID_pk",
+          "columns": ["ModuleID", "UserID"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModuleTeaches": {
+      "name": "ModuleTeaches",
+      "schema": "",
+      "columns": {
+        "ModuleID": {
+          "name": "ModuleID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "UserID": {
+          "name": "UserID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ModuleTeaches_ModuleID_Modules_moduleID_fk": {
+          "name": "ModuleTeaches_ModuleID_Modules_moduleID_fk",
+          "tableFrom": "ModuleTeaches",
+          "tableTo": "Modules",
+          "columnsFrom": ["ModuleID"],
+          "columnsTo": ["moduleID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ModuleTeaches_UserID_user_id_fk": {
+          "name": "ModuleTeaches_UserID_user_id_fk",
+          "tableFrom": "ModuleTeaches",
+          "tableTo": "user",
+          "columnsFrom": ["UserID"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ModuleTeaches_ModuleID_UserID_pk": {
+          "name": "ModuleTeaches_ModuleID_UserID_pk",
+          "columns": ["ModuleID", "UserID"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Modules": {
+      "name": "Modules",
+      "schema": "",
+      "columns": {
+        "moduleID": {
+          "name": "moduleID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "moduleCode": {
+          "name": "moduleCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moduleName": {
+          "name": "moduleName",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moduleDescription": {
+          "name": "moduleDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validated": {
+          "name": "validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "modules_module_code_unique": {
+          "name": "modules_module_code_unique",
+          "columns": [
+            {
+              "expression": "moduleCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PARSE_JOB": {
+      "name": "PARSE_JOB",
+      "schema": "",
+      "columns": {
+        "JobID": {
+          "name": "JobID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "UserID": {
+          "name": "UserID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "UniversityID": {
+          "name": "UniversityID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "AdapterKey": {
+          "name": "AdapterKey",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "FileKey": {
+          "name": "FileKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ClientPdfStreamHash": {
+          "name": "ClientPdfStreamHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "PdfStreamHash": {
+          "name": "PdfStreamHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "FingerprintAlgorithm": {
+          "name": "FingerprintAlgorithm",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "StreamCount": {
+          "name": "StreamCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "GroupID": {
+          "name": "GroupID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "Status": {
+          "name": "Status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "Result": {
+          "name": "Result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ErrorCode": {
+          "name": "ErrorCode",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ErrorMessage": {
+          "name": "ErrorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ErrorDetails": {
+          "name": "ErrorDetails",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "CreatedAt": {
+          "name": "CreatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "UpdatedAt": {
+          "name": "UpdatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "CompletedAt": {
+          "name": "CompletedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "FailedAt": {
+          "name": "FailedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "parse_job_user_id_idx": {
+          "name": "parse_job_user_id_idx",
+          "columns": [
+            {
+              "expression": "UserID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_job_status_idx": {
+          "name": "parse_job_status_idx",
+          "columns": [
+            {
+              "expression": "Status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_job_group_id_idx": {
+          "name": "parse_job_group_id_idx",
+          "columns": [
+            {
+              "expression": "GroupID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_job_created_at_idx": {
+          "name": "parse_job_created_at_idx",
+          "columns": [
+            {
+              "expression": "CreatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "parse_job_duplicate_unique": {
+          "name": "parse_job_duplicate_unique",
+          "columns": [
+            {
+              "expression": "UserID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "UniversityID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "AdapterKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "FingerprintAlgorithm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "PdfStreamHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PARSE_JOB_UserID_user_id_fk": {
+          "name": "PARSE_JOB_UserID_user_id_fk",
+          "tableFrom": "PARSE_JOB",
+          "tableTo": "user",
+          "columnsFrom": ["UserID"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "PARSE_JOB_UniversityID_University_UniversityID_fk": {
+          "name": "PARSE_JOB_UniversityID_University_UniversityID_fk",
+          "tableFrom": "PARSE_JOB",
+          "tableTo": "University",
+          "columnsFrom": ["UniversityID"],
+          "columnsTo": ["UniversityID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "PARSE_JOB_GroupID_ModuleGrouping_GroupID_fk": {
+          "name": "PARSE_JOB_GroupID_ModuleGrouping_GroupID_fk",
+          "tableFrom": "PARSE_JOB",
+          "tableTo": "ModuleGrouping",
+          "columnsFrom": ["GroupID"],
+          "columnsTo": ["GroupID"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EventsToTimetables": {
+      "name": "EventsToTimetables",
+      "schema": "",
+      "columns": {
+        "eventID": {
+          "name": "eventID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timetableID": {
+          "name": "timetableID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "EventsToTimetables_eventID_Event_eventID_fk": {
+          "name": "EventsToTimetables_eventID_Event_eventID_fk",
+          "tableFrom": "EventsToTimetables",
+          "tableTo": "Event",
+          "columnsFrom": ["eventID"],
+          "columnsTo": ["eventID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "EventsToTimetables_timetableID_Timetable_timetableID_fk": {
+          "name": "EventsToTimetables_timetableID_Timetable_timetableID_fk",
+          "tableFrom": "EventsToTimetables",
+          "tableTo": "Timetable",
+          "columnsFrom": ["timetableID"],
+          "columnsTo": ["timetableID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "EventsToTimetables_eventID_timetableID_pk": {
+          "name": "EventsToTimetables_eventID_timetableID_pk",
+          "columns": ["eventID", "timetableID"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Timetable": {
+      "name": "Timetable",
+      "schema": "",
+      "columns": {
+        "timetableID": {
+          "name": "timetableID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "timetableName": {
+          "name": "timetableName",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Timetable_timetableID_unique": {
+          "name": "Timetable_timetableID_unique",
+          "nullsNotDistinct": false,
+          "columns": ["timetableID"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserTimetable": {
+      "name": "UserTimetable",
+      "schema": "",
+      "columns": {
+        "UserTimetableID": {
+          "name": "UserTimetableID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "UserID": {
+          "name": "UserID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "TimetableID": {
+          "name": "TimetableID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserTimetable_UserID_user_id_fk": {
+          "name": "UserTimetable_UserID_user_id_fk",
+          "tableFrom": "UserTimetable",
+          "tableTo": "user",
+          "columnsFrom": ["UserID"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "UserTimetable_TimetableID_Timetable_timetableID_fk": {
+          "name": "UserTimetable_TimetableID_Timetable_timetableID_fk",
+          "tableFrom": "UserTimetable",
+          "tableTo": "Timetable",
+          "columnsFrom": ["TimetableID"],
+          "columnsTo": ["timetableID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AcademicCalendar": {
+      "name": "AcademicCalendar",
+      "schema": "",
+      "columns": {
+        "CalendarID": {
+          "name": "CalendarID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "UniversityID": {
+          "name": "UniversityID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "CreationDate": {
+          "name": "CreationDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "AcademicCalendar_UniversityID_University_UniversityID_fk": {
+          "name": "AcademicCalendar_UniversityID_University_UniversityID_fk",
+          "tableFrom": "AcademicCalendar",
+          "tableTo": "University",
+          "columnsFrom": ["UniversityID"],
+          "columnsTo": ["UniversityID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RestrictedDates": {
+      "name": "RestrictedDates",
+      "schema": "",
+      "columns": {
+        "RestrictionID": {
+          "name": "RestrictionID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "CalendarID": {
+          "name": "CalendarID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "Details": {
+          "name": "Details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"dateStart\":\"\"}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "RestrictedDates_CalendarID_AcademicCalendar_CalendarID_fk": {
+          "name": "RestrictedDates_CalendarID_AcademicCalendar_CalendarID_fk",
+          "tableFrom": "RestrictedDates",
+          "tableTo": "AcademicCalendar",
+          "columnsFrom": ["CalendarID"],
+          "columnsTo": ["CalendarID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Course": {
+      "name": "Course",
+      "schema": "",
+      "columns": {
+        "CourseID": {
+          "name": "CourseID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "UniversityID": {
+          "name": "UniversityID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "GroupID": {
+          "name": "GroupID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "CourseName": {
+          "name": "CourseName",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "Degree": {
+          "name": "Degree",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Course_UniversityID_University_UniversityID_fk": {
+          "name": "Course_UniversityID_University_UniversityID_fk",
+          "tableFrom": "Course",
+          "tableTo": "University",
+          "columnsFrom": ["UniversityID"],
+          "columnsTo": ["UniversityID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Course_GroupID_ModuleGrouping_GroupID_fk": {
+          "name": "Course_GroupID_ModuleGrouping_GroupID_fk",
+          "tableFrom": "Course",
+          "tableTo": "ModuleGrouping",
+          "columnsFrom": ["GroupID"],
+          "columnsTo": ["GroupID"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.CourseModule": {
+      "name": "CourseModule",
+      "schema": "",
+      "columns": {
+        "CourseModuleID": {
+          "name": "CourseModuleID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "CourseID": {
+          "name": "CourseID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "GroupModuleID": {
+          "name": "GroupModuleID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "Core": {
+          "name": "Core",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "SemesterOfStudy": {
+          "name": "SemesterOfStudy",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "YearOfStudy": {
+          "name": "YearOfStudy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "CourseModule_CourseID_Course_CourseID_fk": {
+          "name": "CourseModule_CourseID_Course_CourseID_fk",
+          "tableFrom": "CourseModule",
+          "tableTo": "Course",
+          "columnsFrom": ["CourseID"],
+          "columnsTo": ["CourseID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "CourseModule_GroupModuleID_GroupModules_GroupModuleID_fk": {
+          "name": "CourseModule_GroupModuleID_GroupModules_GroupModuleID_fk",
+          "tableFrom": "CourseModule",
+          "tableTo": "GroupModules",
+          "columnsFrom": ["GroupModuleID"],
+          "columnsTo": ["GroupModuleID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.GroupModules": {
+      "name": "GroupModules",
+      "schema": "",
+      "columns": {
+        "GroupModuleID": {
+          "name": "GroupModuleID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "GroupID": {
+          "name": "GroupID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ModuleID": {
+          "name": "ModuleID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "group_modules_group_module_unique": {
+          "name": "group_modules_group_module_unique",
+          "columns": [
+            {
+              "expression": "GroupID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ModuleID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "GroupModules_GroupID_ModuleGrouping_GroupID_fk": {
+          "name": "GroupModules_GroupID_ModuleGrouping_GroupID_fk",
+          "tableFrom": "GroupModules",
+          "tableTo": "ModuleGrouping",
+          "columnsFrom": ["GroupID"],
+          "columnsTo": ["GroupID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "GroupModules_ModuleID_Modules_moduleID_fk": {
+          "name": "GroupModules_ModuleID_Modules_moduleID_fk",
+          "tableFrom": "GroupModules",
+          "tableTo": "Modules",
+          "columnsFrom": ["ModuleID"],
+          "columnsTo": ["moduleID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModuleGrouping": {
+      "name": "ModuleGrouping",
+      "schema": "",
+      "columns": {
+        "GroupID": {
+          "name": "GroupID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "Hash": {
+          "name": "Hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ModuleGrouping_Hash_unique": {
+          "name": "ModuleGrouping_Hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["Hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.University": {
+      "name": "University",
+      "schema": "",
+      "columns": {
+        "UniversityID": {
+          "name": "UniversityID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "UniversityName": {
+          "name": "UniversityName",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UniversityRole": {
+      "name": "UniversityRole",
+      "schema": "",
+      "columns": {
+        "UserID": {
+          "name": "UserID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "UniversityID": {
+          "name": "UniversityID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "RoleType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STUDENT'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UniversityRole_UserID_user_id_fk": {
+          "name": "UniversityRole_UserID_user_id_fk",
+          "tableFrom": "UniversityRole",
+          "tableTo": "user",
+          "columnsFrom": ["UserID"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "UniversityRole_UniversityID_University_UniversityID_fk": {
+          "name": "UniversityRole_UniversityID_University_UniversityID_fk",
+          "tableFrom": "UniversityRole",
+          "tableTo": "University",
+          "columnsFrom": ["UniversityID"],
+          "columnsTo": ["UniversityID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "UniversityRole_UniversityID_UserID_pk": {
+          "name": "UniversityRole_UniversityID_UserID_pk",
+          "columns": ["UniversityID", "UserID"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EventVenue": {
+      "name": "EventVenue",
+      "schema": "",
+      "columns": {
+        "EventID": {
+          "name": "EventID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "VenueID": {
+          "name": "VenueID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "EventVenue_EventID_Event_eventID_fk": {
+          "name": "EventVenue_EventID_Event_eventID_fk",
+          "tableFrom": "EventVenue",
+          "tableTo": "Event",
+          "columnsFrom": ["EventID"],
+          "columnsTo": ["eventID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "EventVenue_VenueID_Venue_VenueID_fk": {
+          "name": "EventVenue_VenueID_Venue_VenueID_fk",
+          "tableFrom": "EventVenue",
+          "tableTo": "Venue",
+          "columnsFrom": ["VenueID"],
+          "columnsTo": ["VenueID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "EventVenue_EventID_VenueID_pk": {
+          "name": "EventVenue_EventID_VenueID_pk",
+          "columns": ["EventID", "VenueID"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Venue": {
+      "name": "Venue",
+      "schema": "",
+      "columns": {
+        "VenueID": {
+          "name": "VenueID",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "VenueName": {
+          "name": "VenueName",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "UniversityID": {
+          "name": "UniversityID",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "venue_university_name_unique": {
+          "name": "venue_university_name_unique",
+          "columns": [
+            {
+              "expression": "UniversityID",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "VenueName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Venue_UniversityID_University_UniversityID_fk": {
+          "name": "Venue_UniversityID_University_UniversityID_fk",
+          "tableFrom": "Venue",
+          "tableTo": "University",
+          "columnsFrom": ["UniversityID"],
+          "columnsTo": ["UniversityID"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AttendanceState": {
+      "name": "AttendanceState",
+      "schema": "public",
+      "values": ["ATTENDING", "NOT_ATTENDING"]
+    },
+    "public.RestrictionType": {
+      "name": "RestrictionType",
+      "schema": "public",
+      "values": [
+        "DATE-SWAP",
+        "PUBLIC-HOLIDAY",
+        "RECESS",
+        "CLOSURE",
+        "EXAM-PERIOD",
+        "DAY-SWAP"
+      ]
+    },
+    "public.RoleType": {
+      "name": "RoleType",
+      "schema": "public",
+      "values": [
+        "STUDENT",
+        "STUDENT_OWNED",
+        "UNIVERSITY_ADMIN",
+        "UNIVERSITY_ADMIN_PENDING",
+        "LECTURER",
+        "LECTURER_PENDING",
+        "SYSTEM_ADMIN",
+        "REJECTED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1783417040601,
       "tag": "0004_long_rockslide",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1783432425095,
+      "tag": "0005_clean_iceman",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -52,7 +52,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "shared-types": "workspace:*",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
@@ -82,8 +83,7 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.59.4",
-    "zod": "^4.4.3"
+    "typescript-eslint": "^8.59.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/apps/backend/src/Course/dto/course.dto.ts
+++ b/apps/backend/src/Course/dto/course.dto.ts
@@ -1,5 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString, IsUUID, Length } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Length,
+} from 'class-validator';
 import { PartialType, PickType, OmitType } from '@nestjs/swagger';
 
 export class CourseDto {
@@ -21,11 +27,11 @@ export class CourseDto {
   @IsNotEmpty()
   UniversityID!: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: '00000000-0000-0000-0000-000000000000',
     description: 'Unique identifier for a group of modules',
-    required: false,
   })
+  @IsOptional()
   @IsUUID()
   GroupID?: string | null;
 
@@ -39,11 +45,11 @@ export class CourseDto {
   @Length(1, 30)
   CourseName!: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: 'Bachelor of Science',
     description: 'Degree that course belongs to',
-    required: false,
   })
+  @IsOptional()
   @IsString()
   @Length(1, 30)
   Degree?: string | null;

--- a/apps/backend/src/Events/dto/EventDto.dto.ts
+++ b/apps/backend/src/Events/dto/EventDto.dto.ts
@@ -94,6 +94,14 @@ export class EventDto {
   @IsOptional()
   @IsBoolean()
   isRecurring?: boolean;
+
+  @ApiProperty({
+    example: true,
+    description: 'Whether the event has been approved by a university admin',
+  })
+  @IsOptional()
+  @IsBoolean()
+  validated?: boolean;
 } //EventDto
 
 //Create Event
@@ -102,6 +110,7 @@ export class CreateEventDto extends PickType(EventDto, [
   'eventCode',
   'eventCriteria',
   'isRecurring',
+  'validated',
 ] as const) {}
 
 //Update Event

--- a/apps/backend/src/Events/event-import-key.service.spec.ts
+++ b/apps/backend/src/Events/event-import-key.service.spec.ts
@@ -1,0 +1,81 @@
+import { EventType } from './dto/event.types';
+import { EventImportKeyService } from './event-import-key.service';
+
+describe('EventImportKeyService', () => {
+  let service: EventImportKeyService;
+
+  beforeEach(() => {
+    service = new EventImportKeyService();
+  });
+
+  it('builds the same key for the same module event identity', () => {
+    const firstKey = service.buildForEvent({
+      eventName: 'COS101 Lecture',
+      eventCode: 'L1',
+      eventCriteria: {
+        type: EventType.UNIVERSITY,
+        date: 'Monday',
+        startTime: '08:30',
+        endTime: '09:20',
+        moduleID: 'module-1',
+        venue: 'IT 2-26',
+      },
+    });
+    const secondKey = service.buildForEvent({
+      eventName: 'COS101 Lecture',
+      eventCode: 'L1',
+      eventCriteria: {
+        type: EventType.UNIVERSITY,
+        date: 'Monday',
+        startTime: '08:30',
+        endTime: '09:20',
+        moduleID: 'module-1',
+        venue: 'IT 2-26',
+      },
+    });
+
+    expect(firstKey).toBe(secondKey);
+  });
+
+  it('does not build a key for personal events without a module', () => {
+    const key = service.buildForEvent({
+      eventName: 'Study block',
+      eventCode: null,
+      eventCriteria: {
+        type: EventType.PERSONAL,
+        date: '2026-07-03',
+        startTime: '08:30',
+        endTime: '09:20',
+      },
+    });
+
+    expect(key).toBeNull();
+  });
+
+  it('keeps different event identities separate', () => {
+    const firstKey = service.buildForModuleEvent({
+      moduleId: 'AB',
+      eventName: 'C',
+      eventCode: '',
+      eventCriteria: {
+        type: EventType.UNIVERSITY,
+        date: 'Monday',
+        startTime: '08:30',
+        endTime: '09:20',
+      },
+    });
+    const secondKey = service.buildForModuleEvent({
+      moduleId: 'A',
+      eventName: 'BC',
+      eventCode: '',
+      eventCriteria: {
+        type: EventType.UNIVERSITY,
+        date: 'Monday',
+        startTime: '08:30',
+        endTime: '09:20',
+      },
+    });
+
+    expect(firstKey).not.toBe(secondKey);
+  });
+});

--- a/apps/backend/src/Events/event-import-key.service.ts
+++ b/apps/backend/src/Events/event-import-key.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import type { EventCriteria } from './dto/event.types';
+
+export interface EventImportKeyInput {
+  eventName: string;
+  eventCode: string | null | undefined;
+  eventCriteria: EventCriteria;
+}
+
+export interface ModuleEventImportKeyInput {
+  moduleId: string;
+  eventName: string;
+  eventCode: string | null | undefined;
+  eventCriteria: EventCriteria;
+}
+
+@Injectable()
+export class EventImportKeyService {
+  buildForEvent(input: EventImportKeyInput): string | null {
+    const moduleId = input.eventCriteria.moduleID;
+
+    if (!moduleId) {
+      return null;
+    }
+
+    const moduleInput: ModuleEventImportKeyInput = {
+      moduleId: moduleId,
+      eventName: input.eventName,
+      eventCode: input.eventCode,
+      eventCriteria: input.eventCriteria,
+    };
+
+    return this.buildForModuleEvent(moduleInput);
+  }
+
+  buildForModuleEvent(input: ModuleEventImportKeyInput): string {
+    const eventCode = input.eventCode ?? '';
+    const venue = input.eventCriteria.venue ?? '';
+
+    return this.hashImportKey([
+      input.moduleId,
+      input.eventName,
+      eventCode,
+      input.eventCriteria.date,
+      input.eventCriteria.startTime,
+      input.eventCriteria.endTime,
+      venue,
+    ]);
+  }
+
+  private hashImportKey(parts: readonly string[]): string {
+    const hash = createHash('sha256');
+
+    for (const part of parts) {
+      hash.update(this.encodeLength(part.length));
+      hash.update(part);
+    }
+
+    return hash.digest('base64url');
+  }
+
+  private encodeLength(length: number): string {
+    return `${length}:`;
+  }
+}

--- a/apps/backend/src/Events/event.module.ts
+++ b/apps/backend/src/Events/event.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { EventService } from './event.service';
 import { EventController } from './event.controller';
+import { EventImportKeyService } from './event-import-key.service';
 
 import { ModuleModule } from 'src/Module/module.module';
 import { CourseModule } from 'src/Course/course.module';
@@ -8,7 +9,7 @@ import { CourseModule } from 'src/Course/course.module';
 @Module({
   imports: [ModuleModule, CourseModule],
   controllers: [EventController],
-  providers: [EventService],
-  exports: [EventService],
+  providers: [EventService, EventImportKeyService],
+  exports: [EventService, EventImportKeyService],
 })
 export class EventModule {}

--- a/apps/backend/src/Events/event.service.ts
+++ b/apps/backend/src/Events/event.service.ts
@@ -24,16 +24,20 @@ import {
   UpdateEventDto,
   DeleteResponseDto,
   EventDto,
+  UpdateEventCriteriaDto,
 } from './dto/EventDto.dto';
 
 import { AppDatabase } from '../db/database.service';
 import { ModuleService } from '../Module/module.service';
+import { EventImportKeyService } from './event-import-key.service';
+import { EventCriteria } from './dto/event.types';
 
 @Injectable()
 export class EventService {
   constructor(
     private readonly dbService: DatabaseService,
     private readonly moduleService: ModuleService,
+    private readonly eventImportKeyService: EventImportKeyService,
   ) {}
 
   //Create
@@ -95,8 +99,15 @@ export class EventService {
     const recUpdate = dto.isRecurring !== undefined;
     const nameUpdate = dto.eventName !== undefined;
     const codeUpdate = dto.eventCode !== undefined;
+    const validatedUpdate = dto.validated !== undefined;
 
-    if (!critUpdate && !recUpdate && !nameUpdate && !codeUpdate)
+    if (
+      !critUpdate &&
+      !recUpdate &&
+      !nameUpdate &&
+      !codeUpdate &&
+      !validatedUpdate
+    )
       throw new BadRequestException('At least one update field required');
     //END_field presence check
 
@@ -119,23 +130,30 @@ export class EventService {
             `Event not found for eventId: ${eventId}`,
           );
 
-        //Fetch existing criteria
-        const existingCriteria = existingEvent.eventCriteria ?? {};
-
-        //overwrite existing fields if defined in dto
-        const mergedCriteria = {
-          ...existingCriteria,
-          ...dto.eventCriteria,
-        };
+        const mergedCriteria = this.mergeEventCriteria(
+          existingEvent.eventCriteria,
+          dto.eventCriteria,
+        );
+        const nextEventName = dto.eventName?.trim() ?? existingEvent.eventName;
+        const nextEventCode = dto.eventCode?.trim() ?? existingEvent.eventCode;
+        const nextIsRecurring = dto.isRecurring ?? existingEvent.isRecurring;
+        const nextValidated = dto.validated ?? existingEvent.validated;
+        const nextImportKey = this.eventImportKeyService.buildForEvent({
+          eventName: nextEventName ?? '',
+          eventCode: nextEventCode,
+          eventCriteria: mergedCriteria,
+        });
 
         //Update actual event entity
         const [event] = await tx
           .update(Event)
           .set({
-            eventName: dto.eventName?.trim() ?? existingEvent.eventName,
-            eventCode: dto.eventCode?.trim() ?? existingEvent.eventCode,
+            eventName: nextEventName,
+            eventCode: nextEventCode,
             eventCriteria: mergedCriteria,
-            isRecurring: dto.isRecurring ?? existingEvent.isRecurring,
+            isRecurring: nextIsRecurring,
+            validated: nextValidated,
+            ImportKey: nextImportKey,
           })
           .where(eq(Event.eventID, eventId))
           .returning();
@@ -322,6 +340,12 @@ export class EventService {
         eventCode: eventCode,
         eventCriteria: eventCriteria,
         isRecurring: isRec,
+        validated: dto.validated ?? true,
+        ImportKey: this.eventImportKeyService.buildForEvent({
+          eventName: eventName,
+          eventCode: eventCode,
+          eventCriteria: eventCriteria,
+        }),
       })
       .returning();
 
@@ -392,6 +416,37 @@ export class EventService {
       eventCode: event.eventCode ?? undefined,
       eventCriteria: event.eventCriteria,
       isRecurring: event.isRecurring,
+      validated: event.validated,
     };
   } //END_mapEventToDto
+
+  private mergeEventCriteria(
+    existingCriteria: EventCriteria,
+    updateCriteria?: UpdateEventCriteriaDto,
+  ): EventCriteria {
+    if (!updateCriteria) {
+      return existingCriteria;
+    }
+
+    const mergedCriteria: EventCriteria = {
+      type: updateCriteria.type ?? existingCriteria.type,
+      date: updateCriteria.date ?? existingCriteria.date,
+      startTime: updateCriteria.startTime ?? existingCriteria.startTime,
+      endTime: updateCriteria.endTime ?? existingCriteria.endTime,
+    };
+
+    if (updateCriteria.moduleID !== undefined) {
+      mergedCriteria.moduleID = updateCriteria.moduleID;
+    } else if (existingCriteria.moduleID !== undefined) {
+      mergedCriteria.moduleID = existingCriteria.moduleID;
+    }
+
+    if (updateCriteria.venue !== undefined) {
+      mergedCriteria.venue = updateCriteria.venue;
+    } else if (existingCriteria.venue !== undefined) {
+      mergedCriteria.venue = existingCriteria.venue;
+    }
+
+    return mergedCriteria;
+  } //END_mergeEventCriteria
 } //EventService

--- a/apps/backend/src/Grouping/grouping.service.ts
+++ b/apps/backend/src/Grouping/grouping.service.ts
@@ -144,6 +144,7 @@ export class GroupingService {
       .set({
         Hash: hash,
       })
+      .where(eq(ModuleGrouping.GroupID, groupId))
       .returning();
 
     //return updated group with modules

--- a/apps/backend/src/Module/dto/module.dto.ts
+++ b/apps/backend/src/Module/dto/module.dto.ts
@@ -63,10 +63,19 @@ export class ModulesDto {
     },
     type: StylingDto,
   })
+  @IsOptional()
   @IsObject()
   @ValidateNested()
   @Type(() => StylingDto)
   styling?: StylingDto | null;
+
+  @ApiProperty({
+    example: true,
+    description: 'Whether the module has been approved by a university admin',
+  })
+  @IsOptional()
+  @IsBoolean()
+  validated?: boolean;
 } //ModuleDto
 
 //Create
@@ -75,18 +84,21 @@ export class CreateModuleDto extends PickType(ModulesDto, [
   'moduleName',
   'moduleDescription',
   'styling',
+  'validated',
 ]) {
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: '00000000-0000-0000-0000-000000000000',
     description: 'ModuleGroupingID to identify group the module belongs to',
   })
+  @IsOptional()
   @IsUUID()
   ModuleGroupingID?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: '00000000-0000-0000-0000-000000000000',
     description: 'CourseID module belongs to',
   })
+  @IsOptional()
   @IsUUID()
   CourseID?: string;
 } //CreateModuleDto
@@ -136,25 +148,28 @@ export class ModuleFiltersDto {
   @IsUUID()
   courseId?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: '00000000-0000-0000-0000-000000000000',
     description: 'Filter by ModuleGrouping ID',
   })
+  @IsOptional()
   @IsUUID()
   GroupID?: string;
 
   //Filter by code using wildcard
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: 'COS',
     description: 'Filter by code, makes use of wildcard search',
   })
+  @IsOptional()
   @IsString()
   moduleCode?: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: false,
     description: 'Choose to filter modules based of current user enrollments',
   })
+  @IsOptional()
   @IsBoolean()
   userEnrollment?: boolean;
 } //ModuleFiltersDto

--- a/apps/backend/src/Module/module.service.ts
+++ b/apps/backend/src/Module/module.service.ts
@@ -96,6 +96,7 @@ export class ModuleService {
         moduleCode: code,
         moduleName: name,
         moduleDescription: description,
+        ...(dto.validated === undefined ? {} : { validated: dto.validated }),
       })
       .returning();
 
@@ -230,6 +231,8 @@ export class ModuleService {
       dto.moduleDescription.trim() !== oldModule.moduleDescription
     )
       updateFields.moduleDescription = dto.moduleDescription.trim();
+    if (dto.validated !== undefined && dto.validated !== oldModule.validated)
+      updateFields.validated = dto.validated;
 
     let newModule = oldModule;
     //If no updateFields - return module early

--- a/apps/backend/src/Testing/Factories/event.factory.ts
+++ b/apps/backend/src/Testing/Factories/event.factory.ts
@@ -39,6 +39,8 @@ export function createEvent(
     eventName: 'Lecture 1',
     eventCode: 'Lec1',
     isRecurring: false,
+    validated: true,
+    ImportKey: null,
     eventCriteria: createEventCriteria(type, eventCriteriaOverrides),
   };
 

--- a/apps/backend/src/Testing/Factories/module.factory.ts
+++ b/apps/backend/src/Testing/Factories/module.factory.ts
@@ -38,6 +38,7 @@ export function createModule(overrides: Partial<Module> = {}): Module {
     moduleCode: 'COS332',
     moduleName: 'Networks',
     moduleDescription: 'About Networks',
+    validated: false,
 
     ...overrides,
   };

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -16,6 +16,10 @@ import { TimetableModule } from './Timetable/timetable.module';
 import { UniversityModule } from './University/university.module';
 import { CourseModule } from './Course/course.module';
 import { BuilderModule } from './Builder/builder.module';
+import { JobsModule } from './jobs/jobs.module';
+import { PdfParserModule } from './pdf-parser/pdf-parser.module';
+import { SolverModule } from './solver/solver.module';
+import { StorageModule } from './storage/storage.module';
 import { AttendanceModule } from './Attendance/attendance.module';
 import { GroupingModule } from './Grouping/grouping.module';
 
@@ -34,6 +38,10 @@ import { GroupingModule } from './Grouping/grouping.module';
     UniversityModule,
     CourseModule,
     BuilderModule,
+    StorageModule,
+    JobsModule,
+    PdfParserModule,
+    SolverModule,
     AttendanceModule,
     GroupingModule,
   ],

--- a/apps/backend/src/entities/Events/events.schema.ts
+++ b/apps/backend/src/entities/Events/events.schema.ts
@@ -6,6 +6,7 @@ import {
   boolean,
   pgEnum,
   date,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core';
 import { usersTable } from '../auth';
 import { Venue } from '../Universities';
@@ -13,13 +14,21 @@ import { modules } from '../Modules';
 
 import type { EventCriteria } from 'src/Events/dto/event.types';
 
-export const Event = pgTable('Event', {
-  eventID: uuid('eventID').primaryKey().defaultRandom(),
-  eventName: varchar('eventName', { length: 32 }).notNull(),
-  eventCode: varchar('eventCode', { length: 10 }),
-  eventCriteria: jsonb('eventCriteria').$type<EventCriteria>().notNull(),
-  isRecurring: boolean('isRecurring').notNull().default(false),
-});
+export const Event = pgTable(
+  'Event',
+  {
+    eventID: uuid('eventID').primaryKey().defaultRandom(),
+    eventName: varchar('eventName', { length: 32 }).notNull(),
+    eventCode: varchar('eventCode', { length: 10 }),
+    eventCriteria: jsonb('eventCriteria').$type<EventCriteria>().notNull(),
+    isRecurring: boolean('isRecurring').notNull().default(false),
+    validated: boolean('validated').notNull().default(true),
+    ImportKey: varchar('ImportKey', { length: 64 }),
+  },
+  (table) => ({
+    importKeyUnique: uniqueIndex('event_import_key_unique').on(table.ImportKey),
+  }),
+);
 
 //Personal owned
 export const PersonalEvent = pgTable('PersonalEvent', {
@@ -33,18 +42,27 @@ export const PersonalEvent = pgTable('PersonalEvent', {
 });
 
 //University owned
-export const UniversityEvent = pgTable('UniversityEvent', {
-  UniversityEventID: uuid('universityEventID').primaryKey().defaultRandom(),
-  moduleID: uuid('moduleID').references(() => modules.moduleID, {
-    onDelete: 'cascade',
+export const UniversityEvent = pgTable(
+  'UniversityEvent',
+  {
+    UniversityEventID: uuid('universityEventID').primaryKey().defaultRandom(),
+    moduleID: uuid('moduleID').references(() => modules.moduleID, {
+      onDelete: 'cascade',
+    }),
+    eventID: uuid('eventID').references(() => Event.eventID, {
+      onDelete: 'cascade',
+    }),
+    VenueID: uuid('VenueID').references(() => Venue.VenueID, {
+      onDelete: 'cascade',
+    }),
+  },
+  (table) => ({
+    moduleEventUnique: uniqueIndex('university_event_module_event_unique').on(
+      table.moduleID,
+      table.eventID,
+    ),
   }),
-  eventID: uuid('eventID').references(() => Event.eventID, {
-    onDelete: 'cascade',
-  }),
-  VenueID: uuid('VenueID').references(() => Venue.VenueID, {
-    onDelete: 'cascade',
-  }),
-});
+);
 
 export const AttendanceState = pgEnum('AttendanceState', [
   'ATTENDING',

--- a/apps/backend/src/entities/Modules/modules.schema.ts
+++ b/apps/backend/src/entities/Modules/modules.schema.ts
@@ -1,13 +1,30 @@
-import { pgTable, text, uuid, varchar, primaryKey } from 'drizzle-orm/pg-core';
+import {
+  boolean,
+  jsonb,
+  pgTable,
+  text,
+  uuid,
+  varchar,
+  primaryKey,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
 import { usersTable } from '../auth';
-import { jsonb } from 'drizzle-orm/pg-core';
 
-export const modules = pgTable('Modules', {
-  moduleID: uuid('moduleID').defaultRandom().primaryKey(),
-  moduleCode: varchar('moduleCode', { length: 10 }).notNull(),
-  moduleName: varchar('moduleName', { length: 256 }).notNull(),
-  moduleDescription: text('moduleDescription'),
-});
+export const modules = pgTable(
+  'Modules',
+  {
+    moduleID: uuid('moduleID').defaultRandom().primaryKey(),
+    moduleCode: varchar('moduleCode', { length: 10 }).notNull(),
+    moduleName: varchar('moduleName', { length: 256 }).notNull(),
+    moduleDescription: text('moduleDescription'),
+    validated: boolean('validated').notNull().default(true),
+  },
+  (table) => ({
+    moduleCodeUnique: uniqueIndex('modules_module_code_unique').on(
+      table.moduleCode,
+    ),
+  }),
+);
 
 export const ModuleEnrollment = pgTable(
   'ModuleEnrollment',

--- a/apps/backend/src/entities/PdfParser/index.ts
+++ b/apps/backend/src/entities/PdfParser/index.ts
@@ -1,0 +1,1 @@
+export * from './parse-job.schema';

--- a/apps/backend/src/entities/PdfParser/parse-job.schema.ts
+++ b/apps/backend/src/entities/PdfParser/parse-job.schema.ts
@@ -11,7 +11,7 @@ import {
 } from 'drizzle-orm/pg-core';
 import type { PdfParserResult } from 'shared-types';
 import { usersTable } from '../auth';
-import { University } from '../Universities';
+import { ModuleGrouping, University } from '../Universities';
 
 export const parseJob = pgTable(
   'PARSE_JOB',
@@ -31,6 +31,9 @@ export const parseJob = pgTable(
       length: 128,
     }).notNull(),
     StreamCount: integer('StreamCount').notNull(),
+    GroupID: uuid('GroupID').references(() => ModuleGrouping.GroupID, {
+      onDelete: 'set null',
+    }),
     Status: varchar('Status', { length: 32 }).notNull().default('queued'),
     Result: jsonb('Result').$type<PdfParserResult | null>(),
     ErrorCode: varchar('ErrorCode', { length: 128 }),
@@ -48,6 +51,7 @@ export const parseJob = pgTable(
   (table) => ({
     userIndex: index('parse_job_user_id_idx').on(table.UserID),
     statusIndex: index('parse_job_status_idx').on(table.Status),
+    groupIndex: index('parse_job_group_id_idx').on(table.GroupID),
     createdAtIndex: index('parse_job_created_at_idx').on(table.CreatedAt),
     duplicateUniqueIndex: uniqueIndex('parse_job_duplicate_unique').on(
       table.UserID,

--- a/apps/backend/src/entities/PdfParser/parse-job.schema.ts
+++ b/apps/backend/src/entities/PdfParser/parse-job.schema.ts
@@ -1,0 +1,62 @@
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+import type { PdfParserResult } from 'shared-types';
+import { usersTable } from '../auth';
+import { University } from '../Universities';
+
+export const parseJob = pgTable(
+  'PARSE_JOB',
+  {
+    JobID: uuid('JobID').primaryKey(),
+    UserID: uuid('UserID')
+      .notNull()
+      .references(() => usersTable.id, { onDelete: 'cascade' }),
+    UniversityID: uuid('UniversityID')
+      .notNull()
+      .references(() => University.UniversityID, { onDelete: 'cascade' }),
+    AdapterKey: varchar('AdapterKey', { length: 64 }).notNull(),
+    FileKey: text('FileKey'),
+    ClientPdfStreamHash: varchar('ClientPdfStreamHash', { length: 64 }),
+    PdfStreamHash: varchar('PdfStreamHash', { length: 64 }).notNull(),
+    FingerprintAlgorithm: varchar('FingerprintAlgorithm', {
+      length: 128,
+    }).notNull(),
+    StreamCount: integer('StreamCount').notNull(),
+    Status: varchar('Status', { length: 32 }).notNull().default('queued'),
+    Result: jsonb('Result').$type<PdfParserResult | null>(),
+    ErrorCode: varchar('ErrorCode', { length: 128 }),
+    ErrorMessage: text('ErrorMessage'),
+    ErrorDetails: jsonb('ErrorDetails').$type<Record<string, unknown> | null>(),
+    CreatedAt: timestamp('CreatedAt', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    UpdatedAt: timestamp('UpdatedAt', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    CompletedAt: timestamp('CompletedAt', { withTimezone: true }),
+    FailedAt: timestamp('FailedAt', { withTimezone: true }),
+  },
+  (table) => ({
+    userIndex: index('parse_job_user_id_idx').on(table.UserID),
+    statusIndex: index('parse_job_status_idx').on(table.Status),
+    createdAtIndex: index('parse_job_created_at_idx').on(table.CreatedAt),
+    duplicateUniqueIndex: uniqueIndex('parse_job_duplicate_unique').on(
+      table.UserID,
+      table.UniversityID,
+      table.AdapterKey,
+      table.FingerprintAlgorithm,
+      table.PdfStreamHash,
+    ),
+  }),
+);
+
+export type ParseJob = typeof parseJob.$inferSelect;

--- a/apps/backend/src/entities/Universities/Venue.schema.ts
+++ b/apps/backend/src/entities/Universities/Venue.schema.ts
@@ -1,14 +1,29 @@
-import { pgTable, uuid, varchar, primaryKey } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  uuid,
+  varchar,
+  primaryKey,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
 import { University } from './University.schema';
 import { Event } from '../Events/index';
 
-export const Venue = pgTable('Venue', {
-  VenueID: uuid('VenueID').primaryKey().defaultRandom(),
-  VenueName: varchar('VenueName', { length: 30 }),
-  UniversityID: uuid('UniversityID')
-    .references(() => University.UniversityID, { onDelete: 'cascade' })
-    .notNull(),
-});
+export const Venue = pgTable(
+  'Venue',
+  {
+    VenueID: uuid('VenueID').primaryKey().defaultRandom(),
+    VenueName: varchar('VenueName', { length: 30 }),
+    UniversityID: uuid('UniversityID')
+      .references(() => University.UniversityID, { onDelete: 'cascade' })
+      .notNull(),
+  },
+  (table) => ({
+    universityVenueNameUnique: uniqueIndex('venue_university_name_unique').on(
+      table.UniversityID,
+      table.VenueName,
+    ),
+  }),
+);
 
 //Changing EventVenue to be linked to event instead of university, since this join table is for events to venues
 //Moving the universityID to the venue table

--- a/apps/backend/src/entities/Universities/course.schema.ts
+++ b/apps/backend/src/entities/Universities/course.schema.ts
@@ -1,4 +1,11 @@
-import { pgTable, uuid, varchar, integer, boolean } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  uuid,
+  varchar,
+  integer,
+  boolean,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
 import { modules } from '../Modules';
 import { University } from './University.schema';
 
@@ -23,15 +30,24 @@ export const Course = pgTable('Course', {
 });
 
 //Join table defining modules grouped together to ModuleGrouping
-export const GroupModules = pgTable('GroupModules', {
-  GroupModuleID: uuid('GroupModuleID').primaryKey().defaultRandom(),
-  GroupID: uuid('GroupID')
-    .references(() => ModuleGrouping.GroupID, { onDelete: 'cascade' })
-    .notNull(),
-  ModuleID: uuid('ModuleID')
-    .references(() => modules.moduleID, { onDelete: 'cascade' })
-    .notNull(),
-});
+export const GroupModules = pgTable(
+  'GroupModules',
+  {
+    GroupModuleID: uuid('GroupModuleID').primaryKey().defaultRandom(),
+    GroupID: uuid('GroupID')
+      .references(() => ModuleGrouping.GroupID, { onDelete: 'cascade' })
+      .notNull(),
+    ModuleID: uuid('ModuleID')
+      .references(() => modules.moduleID, { onDelete: 'cascade' })
+      .notNull(),
+  },
+  (table) => ({
+    groupModuleUnique: uniqueIndex('group_modules_group_module_unique').on(
+      table.GroupID,
+      table.ModuleID,
+    ),
+  }),
+);
 
 //Metadata for specific module in a grouping when course is defined
 export const CourseModule = pgTable('CourseModule', {

--- a/apps/backend/src/entities/index.ts
+++ b/apps/backend/src/entities/index.ts
@@ -1,5 +1,6 @@
 export * from './auth/index';
 export * from './Events/index';
 export * from './Modules/index';
+export * from './PdfParser/index';
 export * from './timetables/index';
 export * from './Universities/index';

--- a/apps/backend/src/pdf-parser/dto/pdf-parser-callback.dto.ts
+++ b/apps/backend/src/pdf-parser/dto/pdf-parser-callback.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsIn,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import type { PdfParserCallbackPayload } from 'shared-types';
+
+export class WorkerCallbackErrorDto {
+  @ApiProperty({ example: 'PARSER_FAILED' })
+  @IsString()
+  code!: string;
+
+  @ApiProperty({ example: 'PDF parser failed' })
+  @IsString()
+  message!: string;
+
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true })
+  @IsOptional()
+  @IsObject()
+  details?: Record<string, unknown>;
+}
+
+export class PdfParserCallbackDto implements PdfParserCallbackPayload {
+  @ApiProperty({ enum: ['completed', 'failed'] })
+  @IsIn(['completed', 'failed'])
+  status!: 'completed' | 'failed';
+
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true })
+  @IsOptional()
+  @IsObject()
+  result?: PdfParserCallbackPayload['result'];
+
+  @ApiPropertyOptional({ type: () => WorkerCallbackErrorDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => WorkerCallbackErrorDto)
+  error?: WorkerCallbackErrorDto;
+}

--- a/apps/backend/src/pdf-parser/dto/pdf-parser-job-response.dto.ts
+++ b/apps/backend/src/pdf-parser/dto/pdf-parser-job-response.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { PdfParserResult, WorkerCallbackError } from 'shared-types';
+
+export class PdfParserJobResponseDto {
+  @ApiProperty({ example: 'pdf-parse-2d82d1ff-fb51-4c67-80cf-61d88c12d596' })
+  jobId!: string;
+
+  @ApiPropertyOptional({
+    example:
+      'uploads/pdf-parser/pdf-parse-2d82d1ff-fb51-4c67-80cf-61d88c12d596/timetable.pdf',
+    nullable: true,
+  })
+  fileKey!: string | null;
+
+  @ApiPropertyOptional({ example: 'up', nullable: true })
+  adapterKey!: string | null;
+
+  @ApiProperty({ enum: ['queued', 'completed', 'failed'] })
+  status!: 'queued' | 'completed' | 'failed';
+
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true })
+  result?: PdfParserResult;
+
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true })
+  error?: WorkerCallbackError;
+
+  @ApiProperty({ example: '2026-07-02T10:15:30.000Z' })
+  createdAt!: string;
+
+  @ApiProperty({ example: '2026-07-02T10:15:45.000Z' })
+  updatedAt!: string;
+}
+
+export class PdfParserUploadResponseDto extends PdfParserJobResponseDto {
+  @ApiProperty({
+    example: '/pdf-parser/jobs/pdf-parse-2d82d1ff-fb51-4c67-80cf-61d88c12d596',
+  })
+  statusUrl!: string;
+}

--- a/apps/backend/src/pdf-parser/dto/pdf-parser-job-response.dto.ts
+++ b/apps/backend/src/pdf-parser/dto/pdf-parser-job-response.dto.ts
@@ -37,3 +37,24 @@ export class PdfParserUploadResponseDto extends PdfParserJobResponseDto {
   })
   statusUrl!: string;
 }
+
+export class PdfParserLookupResponseDto {
+  @ApiProperty({ example: true })
+  duplicate!: boolean;
+
+  @ApiPropertyOptional({
+    example: 'pdf-parse-2d82d1ff-fb51-4c67-80cf-61d88c12d596',
+  })
+  jobId?: string;
+
+  @ApiPropertyOptional({ enum: ['queued', 'completed', 'failed'] })
+  status?: 'queued' | 'completed' | 'failed';
+
+  @ApiPropertyOptional({ example: true })
+  resultAvailable?: boolean;
+
+  @ApiPropertyOptional({
+    example: '/pdf-parser/jobs/pdf-parse-2d82d1ff-fb51-4c67-80cf-61d88c12d596',
+  })
+  statusUrl?: string;
+}

--- a/apps/backend/src/pdf-parser/dto/pdf-parser-job-response.dto.ts
+++ b/apps/backend/src/pdf-parser/dto/pdf-parser-job-response.dto.ts
@@ -24,6 +24,12 @@ export class PdfParserJobResponseDto {
   @ApiPropertyOptional({ type: 'object', additionalProperties: true })
   error?: WorkerCallbackError;
 
+  @ApiPropertyOptional({
+    example: '00000000-0000-0000-0000-000000000000',
+    nullable: true,
+  })
+  moduleGroupingId?: string | null;
+
   @ApiProperty({ example: '2026-07-02T10:15:30.000Z' })
   createdAt!: string;
 
@@ -49,6 +55,12 @@ export class PdfParserLookupResponseDto {
 
   @ApiPropertyOptional({ enum: ['queued', 'completed', 'failed'] })
   status?: 'queued' | 'completed' | 'failed';
+
+  @ApiPropertyOptional({
+    example: '00000000-0000-0000-0000-000000000000',
+    nullable: true,
+  })
+  moduleGroupingId?: string | null;
 
   @ApiPropertyOptional({ example: true })
   resultAvailable?: boolean;

--- a/apps/backend/src/pdf-parser/event-importer.service.ts
+++ b/apps/backend/src/pdf-parser/event-importer.service.ts
@@ -1,0 +1,207 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import type { ParsedEventCandidate } from 'shared-types';
+import type { AppDatabase } from '../db/database.service';
+import type { EventCriteria } from '../Events/dto/event.types';
+import { EventType } from '../Events/dto/event.types';
+import { Event, EventVenue, UniversityEvent, Venue } from '../entities';
+import type { ModuleRecord } from './module-resolver.service';
+import {
+  normalizeModuleCode,
+  truncateForColumn,
+} from './pdf-parser-import.utils';
+
+interface ImportedEventShape {
+  eventName: string;
+  eventCode: string;
+  eventCriteria: EventCriteria;
+}
+
+interface EventCriteriaInput {
+  moduleId: string;
+  parsedEvent: ParsedEventCandidate;
+  primaryVenue?: string;
+}
+
+@Injectable()
+export class EventImporter {
+  async createMissingEvents(
+    db: AppDatabase,
+    universityId: string,
+    parsedEvents: ParsedEventCandidate[],
+    moduleByCode: Map<string, ModuleRecord>,
+  ): Promise<void> {
+    for (const parsedEvent of parsedEvents) {
+      const module = moduleByCode.get(
+        normalizeModuleCode(parsedEvent.moduleCode),
+      );
+      if (!module) {
+        continue;
+      }
+
+      const eventShape = this.buildEventShape(module.moduleID, parsedEvent);
+      const existing = await this.findExistingEvent(
+        db,
+        module.moduleID,
+        eventShape,
+      );
+      if (existing) {
+        continue;
+      }
+
+      const venueIds = await this.resolveVenueIds(
+        db,
+        universityId,
+        parsedEvent.venues,
+      );
+      const primaryVenueId = venueIds[0];
+
+      const [event] = await db
+        .insert(Event)
+        .values({
+          eventName: eventShape.eventName,
+          eventCode: eventShape.eventCode,
+          eventCriteria: eventShape.eventCriteria,
+          isRecurring: parsedEvent.isRecurring,
+          validated: false,
+        })
+        .returning();
+
+      if (!event) {
+        throw new ConflictException('PDF parser event could not be created');
+      }
+
+      await db.insert(UniversityEvent).values({
+        moduleID: module.moduleID,
+        eventID: event.eventID,
+        VenueID: primaryVenueId,
+      });
+
+      if (venueIds.length > 0) {
+        await db.insert(EventVenue).values(
+          venueIds.map((venueId) => ({
+            EventID: event.eventID,
+            VenueID: venueId,
+          })),
+        );
+      }
+    }
+  }
+
+  private async findExistingEvent(
+    db: AppDatabase,
+    moduleId: string,
+    eventShape: ImportedEventShape,
+  ): Promise<typeof Event.$inferSelect | undefined> {
+    const rows = await db
+      .select({
+        event: Event,
+      })
+      .from(Event)
+      .innerJoin(UniversityEvent, eq(UniversityEvent.eventID, Event.eventID))
+      .where(eq(UniversityEvent.moduleID, moduleId));
+
+    return rows.find(({ event }) => this.eventMatchesShape(event, eventShape))
+      ?.event;
+  }
+
+  private async resolveVenueIds(
+    db: AppDatabase,
+    universityId: string,
+    venueNames: string[],
+  ): Promise<string[]> {
+    const ids: string[] = [];
+    const seenNames = new Set<string>();
+
+    for (const rawName of venueNames) {
+      const name = truncateForColumn(rawName.trim(), 30);
+      if (!name || seenNames.has(name)) {
+        continue;
+      }
+      seenNames.add(name);
+
+      const [existingVenue] = await db
+        .select()
+        .from(Venue)
+        .where(
+          and(eq(Venue.UniversityID, universityId), eq(Venue.VenueName, name)),
+        )
+        .limit(1);
+
+      if (existingVenue) {
+        ids.push(existingVenue.VenueID);
+        continue;
+      }
+
+      const [venue] = await db
+        .insert(Venue)
+        .values({
+          VenueName: name,
+          UniversityID: universityId,
+        })
+        .returning();
+
+      if (venue) {
+        ids.push(venue.VenueID);
+      }
+    }
+
+    return ids;
+  }
+
+  private buildEventShape(
+    moduleId: string,
+    parsedEvent: ParsedEventCandidate,
+  ): ImportedEventShape {
+    const primaryVenue = parsedEvent.venues[0]?.trim();
+
+    return {
+      eventName: truncateForColumn(
+        parsedEvent.title.trim() ||
+          `${normalizeModuleCode(parsedEvent.moduleCode)} ${parsedEvent.type}`,
+        32,
+      ),
+      eventCode: truncateForColumn(
+        parsedEvent.sectionLabel.trim() || parsedEvent.type,
+        10,
+      ),
+      eventCriteria: this.buildEventCriteria({
+        moduleId,
+        parsedEvent,
+        primaryVenue,
+      }),
+    };
+  }
+
+  private buildEventCriteria(input: EventCriteriaInput): EventCriteria {
+    const criteria: EventCriteria = {
+      type: EventType.UNIVERSITY,
+      date: input.parsedEvent.date ?? input.parsedEvent.day ?? '',
+      startTime: input.parsedEvent.startTime,
+      endTime: input.parsedEvent.endTime,
+      moduleID: input.moduleId,
+    };
+
+    if (input.primaryVenue) {
+      criteria.venue = truncateForColumn(input.primaryVenue, 30);
+    }
+
+    return criteria;
+  }
+
+  private eventMatchesShape(
+    event: typeof Event.$inferSelect,
+    eventShape: ImportedEventShape,
+  ): boolean {
+    return (
+      event.eventName === eventShape.eventName &&
+      (event.eventCode ?? '') === eventShape.eventCode &&
+      event.eventCriteria.moduleID === eventShape.eventCriteria.moduleID &&
+      event.eventCriteria.date === eventShape.eventCriteria.date &&
+      event.eventCriteria.startTime === eventShape.eventCriteria.startTime &&
+      event.eventCriteria.endTime === eventShape.eventCriteria.endTime &&
+      (event.eventCriteria.venue ?? '') ===
+        (eventShape.eventCriteria.venue ?? '')
+    );
+  }
+}

--- a/apps/backend/src/pdf-parser/event-importer.service.ts
+++ b/apps/backend/src/pdf-parser/event-importer.service.ts
@@ -4,6 +4,7 @@ import type { ParsedEventCandidate } from 'shared-types';
 import type { AppDatabase } from '../db/database.service';
 import type { EventCriteria } from '../Events/dto/event.types';
 import { EventType } from '../Events/dto/event.types';
+import { EventImportKeyService } from '../Events/event-import-key.service';
 import { Event, EventVenue, UniversityEvent, Venue } from '../entities';
 import type { ModuleRecord } from './module-resolver.service';
 import {
@@ -15,6 +16,7 @@ interface ImportedEventShape {
   eventName: string;
   eventCode: string;
   eventCriteria: EventCriteria;
+  importKey: string;
 }
 
 interface EventCriteriaInput {
@@ -25,6 +27,8 @@ interface EventCriteriaInput {
 
 @Injectable()
 export class EventImporter {
+  constructor(private readonly eventImportKeyService: EventImportKeyService) {}
+
   async createMissingEvents(
     db: AppDatabase,
     universityId: string,
@@ -56,36 +60,74 @@ export class EventImporter {
       );
       const primaryVenueId = venueIds[0];
 
-      const [event] = await db
-        .insert(Event)
+      const event = await this.createOrFindEvent(
+        db,
+        eventShape,
+        parsedEvent.isRecurring,
+      );
+
+      await db
+        .insert(UniversityEvent)
         .values({
-          eventName: eventShape.eventName,
-          eventCode: eventShape.eventCode,
-          eventCriteria: eventShape.eventCriteria,
-          isRecurring: parsedEvent.isRecurring,
-          validated: false,
+          moduleID: module.moduleID,
+          eventID: event.eventID,
+          VenueID: primaryVenueId,
         })
-        .returning();
-
-      if (!event) {
-        throw new ConflictException('PDF parser event could not be created');
-      }
-
-      await db.insert(UniversityEvent).values({
-        moduleID: module.moduleID,
-        eventID: event.eventID,
-        VenueID: primaryVenueId,
-      });
+        .onConflictDoNothing({
+          target: [UniversityEvent.moduleID, UniversityEvent.eventID],
+        });
 
       if (venueIds.length > 0) {
-        await db.insert(EventVenue).values(
-          venueIds.map((venueId) => ({
-            EventID: event.eventID,
-            VenueID: venueId,
-          })),
-        );
+        for (const venueId of venueIds) {
+          await db
+            .insert(EventVenue)
+            .values({
+              EventID: event.eventID,
+              VenueID: venueId,
+            })
+            .onConflictDoNothing({
+              target: [EventVenue.EventID, EventVenue.VenueID],
+            });
+        }
       }
     }
+  }
+
+  private async createOrFindEvent(
+    db: AppDatabase,
+    eventShape: ImportedEventShape,
+    isRecurring: boolean,
+  ): Promise<typeof Event.$inferSelect> {
+    const [inserted] = await db
+      .insert(Event)
+      .values({
+        eventName: eventShape.eventName,
+        eventCode: eventShape.eventCode,
+        eventCriteria: eventShape.eventCriteria,
+        isRecurring,
+        validated: false,
+        ImportKey: eventShape.importKey,
+      })
+      .onConflictDoNothing({
+        target: Event.ImportKey,
+      })
+      .returning();
+
+    if (inserted) {
+      return inserted;
+    }
+
+    const [existing] = await db
+      .select()
+      .from(Event)
+      .where(eq(Event.ImportKey, eventShape.importKey))
+      .limit(1);
+
+    if (!existing) {
+      throw new ConflictException('PDF parser event could not be resolved');
+    }
+
+    return existing;
   }
 
   private async findExistingEvent(
@@ -139,10 +181,26 @@ export class EventImporter {
           VenueName: name,
           UniversityID: universityId,
         })
+        .onConflictDoNothing({
+          target: [Venue.UniversityID, Venue.VenueName],
+        })
         .returning();
 
       if (venue) {
         ids.push(venue.VenueID);
+        continue;
+      }
+
+      const [conflictingVenue] = await db
+        .select()
+        .from(Venue)
+        .where(
+          and(eq(Venue.UniversityID, universityId), eq(Venue.VenueName, name)),
+        )
+        .limit(1);
+
+      if (conflictingVenue) {
+        ids.push(conflictingVenue.VenueID);
       }
     }
 
@@ -154,21 +212,30 @@ export class EventImporter {
     parsedEvent: ParsedEventCandidate,
   ): ImportedEventShape {
     const primaryVenue = parsedEvent.venues[0]?.trim();
+    const eventName = truncateForColumn(
+      parsedEvent.title.trim() ||
+        `${normalizeModuleCode(parsedEvent.moduleCode)} ${parsedEvent.type}`,
+      32,
+    );
+    const eventCode = truncateForColumn(
+      parsedEvent.sectionLabel.trim() || parsedEvent.type,
+      10,
+    );
+    const eventCriteria = this.buildEventCriteria({
+      moduleId,
+      parsedEvent,
+      primaryVenue,
+    });
 
     return {
-      eventName: truncateForColumn(
-        parsedEvent.title.trim() ||
-          `${normalizeModuleCode(parsedEvent.moduleCode)} ${parsedEvent.type}`,
-        32,
-      ),
-      eventCode: truncateForColumn(
-        parsedEvent.sectionLabel.trim() || parsedEvent.type,
-        10,
-      ),
-      eventCriteria: this.buildEventCriteria({
-        moduleId,
-        parsedEvent,
-        primaryVenue,
+      eventName,
+      eventCode,
+      eventCriteria,
+      importKey: this.eventImportKeyService.buildForModuleEvent({
+        moduleId: moduleId,
+        eventName: eventName,
+        eventCode: eventCode,
+        eventCriteria: eventCriteria,
       }),
     };
   }

--- a/apps/backend/src/pdf-parser/module-resolver.service.ts
+++ b/apps/backend/src/pdf-parser/module-resolver.service.ts
@@ -42,25 +42,52 @@ export class ModuleResolver {
       return resolved;
     }
 
-    const inserted = await db
-      .insert(modules)
-      .values(
-        missingCandidates.map(([code, candidate]) => ({
-          moduleCode: normalizeModuleCode(code),
-          moduleName: truncateForColumn(candidate.name?.trim() || code, 256),
-          moduleDescription: candidate.metadata
-            ? JSON.stringify(candidate.metadata)
-            : null,
-          validated: false,
-        })),
-      )
-      .returning();
-
-    for (const module of inserted) {
+    for (const entry of missingCandidates) {
+      const code = entry[0];
+      const candidate = entry[1];
+      const module = await this.createOrFindModule(db, code, candidate);
       resolved.set(module.moduleCode, module);
     }
 
     return resolved;
+  }
+
+  private async createOrFindModule(
+    db: AppDatabase,
+    code: string,
+    candidate: ParsedModuleCandidate,
+  ): Promise<ModuleRecord> {
+    const normalizedCode = normalizeModuleCode(code);
+    const [inserted] = await db
+      .insert(modules)
+      .values({
+        moduleCode: normalizedCode,
+        moduleName: truncateForColumn(candidate.name?.trim() || code, 256),
+        moduleDescription: candidate.metadata
+          ? JSON.stringify(candidate.metadata)
+          : null,
+        validated: false,
+      })
+      .onConflictDoNothing({
+        target: modules.moduleCode,
+      })
+      .returning();
+
+    if (inserted) {
+      return inserted;
+    }
+
+    const [existing] = await db
+      .select()
+      .from(modules)
+      .where(eq(modules.moduleCode, normalizedCode))
+      .limit(1);
+
+    if (!existing) {
+      throw new Error(`PDF parser module could not be resolved: ${code}`);
+    }
+
+    return existing;
   }
 
   private async findModulesOwnedByUniversityViaGroupLinks(

--- a/apps/backend/src/pdf-parser/module-resolver.service.ts
+++ b/apps/backend/src/pdf-parser/module-resolver.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, inArray, or } from 'drizzle-orm';
+import type { ParsedModuleCandidate } from 'shared-types';
+import type { AppDatabase } from '../db/database.service';
+import { Course, GroupModules, modules, parseJob } from '../entities';
+import {
+  normalizeModuleCode,
+  truncateForColumn,
+} from './pdf-parser-import.utils';
+
+export type ModuleRecord = typeof modules.$inferSelect;
+
+@Injectable()
+export class ModuleResolver {
+  async resolveForUniversity(
+    db: AppDatabase,
+    universityId: string,
+    candidates: Map<string, ParsedModuleCandidate>,
+  ): Promise<Map<string, ModuleRecord>> {
+    const resolved = new Map<string, ModuleRecord>();
+    const codes = Array.from(candidates.keys());
+
+    if (codes.length > 0) {
+      const existingRows = await this.findModulesOwnedByUniversityViaGroupLinks(
+        db,
+        universityId,
+        codes,
+      );
+
+      for (const row of existingRows) {
+        if (!resolved.has(row.module.moduleCode)) {
+          resolved.set(row.module.moduleCode, row.module);
+        }
+      }
+    }
+
+    const missingCandidates = Array.from(candidates.entries()).filter(
+      ([code]) => !resolved.has(code),
+    );
+
+    if (missingCandidates.length === 0) {
+      return resolved;
+    }
+
+    const inserted = await db
+      .insert(modules)
+      .values(
+        missingCandidates.map(([code, candidate]) => ({
+          moduleCode: normalizeModuleCode(code),
+          moduleName: truncateForColumn(candidate.name?.trim() || code, 256),
+          moduleDescription: candidate.metadata
+            ? JSON.stringify(candidate.metadata)
+            : null,
+          validated: false,
+        })),
+      )
+      .returning();
+
+    for (const module of inserted) {
+      resolved.set(module.moduleCode, module);
+    }
+
+    return resolved;
+  }
+
+  private async findModulesOwnedByUniversityViaGroupLinks(
+    db: AppDatabase,
+    universityId: string,
+    codes: string[],
+  ): Promise<{ module: ModuleRecord }[]> {
+    // Modules have no direct university owner. Reuse is intentionally limited to
+    // modules linked through a university course or an earlier parser job.
+    return db
+      .select({
+        module: modules,
+      })
+      .from(modules)
+      .innerJoin(GroupModules, eq(GroupModules.ModuleID, modules.moduleID))
+      .leftJoin(Course, eq(Course.GroupID, GroupModules.GroupID))
+      .leftJoin(parseJob, eq(parseJob.GroupID, GroupModules.GroupID))
+      .where(
+        and(
+          inArray(modules.moduleCode, codes),
+          or(
+            eq(Course.UniversityID, universityId),
+            eq(parseJob.UniversityID, universityId),
+          ),
+        ),
+      );
+  }
+}

--- a/apps/backend/src/pdf-parser/parser-result-importer.service.ts
+++ b/apps/backend/src/pdf-parser/parser-result-importer.service.ts
@@ -75,7 +75,7 @@ export class ParserResultImporter {
     db: AppDatabase,
     moduleIds: string[],
   ): Promise<string> {
-    const sortedModuleIds = [...new Set(moduleIds)].sort();
+    const sortedModuleIds = uniqueSortedValues(moduleIds);
     const hash =
       sortedModuleIds.length > 0 ? hashModuleIds(sortedModuleIds) : null;
 
@@ -87,6 +87,11 @@ export class ParserResultImporter {
         .limit(1);
 
       if (existingGroup) {
+        await this.assertGroupModulesMatch(
+          db,
+          existingGroup.GroupID,
+          sortedModuleIds,
+        );
         return existingGroup.GroupID;
       }
     }
@@ -94,7 +99,27 @@ export class ParserResultImporter {
     const [group] = await db
       .insert(ModuleGrouping)
       .values(hash ? { Hash: hash } : {})
+      .onConflictDoNothing({
+        target: ModuleGrouping.Hash,
+      })
       .returning();
+
+    if (!group && hash) {
+      const [conflictingGroup] = await db
+        .select()
+        .from(ModuleGrouping)
+        .where(eq(ModuleGrouping.Hash, hash))
+        .limit(1);
+
+      if (conflictingGroup) {
+        await this.assertGroupModulesMatch(
+          db,
+          conflictingGroup.GroupID,
+          sortedModuleIds,
+        );
+        return conflictingGroup.GroupID;
+      }
+    }
 
     if (!group) {
       throw new ConflictException(
@@ -103,14 +128,64 @@ export class ParserResultImporter {
     }
 
     if (sortedModuleIds.length > 0) {
-      await db.insert(GroupModules).values(
-        sortedModuleIds.map((moduleId) => ({
-          GroupID: group.GroupID,
-          ModuleID: moduleId,
-        })),
-      );
+      for (const moduleId of sortedModuleIds) {
+        await db
+          .insert(GroupModules)
+          .values({
+            GroupID: group.GroupID,
+            ModuleID: moduleId,
+          })
+          .onConflictDoNothing({
+            target: [GroupModules.GroupID, GroupModules.ModuleID],
+          });
+      }
     }
 
     return group.GroupID;
   }
+
+  private async assertGroupModulesMatch(
+    db: AppDatabase,
+    groupId: string,
+    sortedModuleIds: string[],
+  ): Promise<void> {
+    const rows = await db
+      .select({
+        moduleId: GroupModules.ModuleID,
+      })
+      .from(GroupModules)
+      .where(eq(GroupModules.GroupID, groupId));
+
+    const existingModuleIds = rows
+      .map((row) => row.moduleId)
+      .sort(compareStrings);
+
+    if (!sameStringList(existingModuleIds, sortedModuleIds)) {
+      throw new ConflictException(
+        'PDF parser module grouping hash does not match group membership',
+      );
+    }
+  }
+}
+
+function uniqueSortedValues(values: string[]): string[] {
+  return Array.from(new Set(values)).sort(compareStrings);
+}
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function sameStringList(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/apps/backend/src/pdf-parser/parser-result-importer.service.ts
+++ b/apps/backend/src/pdf-parser/parser-result-importer.service.ts
@@ -1,0 +1,116 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import type { ParsedModuleCandidate, PdfParserResult } from 'shared-types';
+import type { AppDatabase } from '../db/database.service';
+import { GroupModules, ModuleGrouping, type ParseJob } from '../entities';
+import { EventImporter } from './event-importer.service';
+import { ModuleResolver } from './module-resolver.service';
+import { hashModuleIds, normalizeModuleCode } from './pdf-parser-import.utils';
+
+@Injectable()
+export class ParserResultImporter {
+  constructor(
+    private readonly moduleResolver: ModuleResolver,
+    private readonly eventImporter: EventImporter,
+  ) {}
+
+  async importResult(
+    db: AppDatabase,
+    job: ParseJob,
+    result: PdfParserResult,
+  ): Promise<string> {
+    const candidateByCode = this.collectModuleCandidates(result);
+    const moduleByCode = await this.moduleResolver.resolveForUniversity(
+      db,
+      job.UniversityID,
+      candidateByCode,
+    );
+    const moduleGroupingId = await this.createOrReuseModuleGrouping(
+      db,
+      Array.from(moduleByCode.values()).map((module) => module.moduleID),
+    );
+
+    await this.eventImporter.createMissingEvents(
+      db,
+      job.UniversityID,
+      result.events,
+      moduleByCode,
+    );
+
+    return moduleGroupingId;
+  }
+
+  private collectModuleCandidates(
+    result: PdfParserResult,
+  ): Map<string, ParsedModuleCandidate> {
+    const candidates = new Map<string, ParsedModuleCandidate>();
+
+    for (const candidate of result.modules) {
+      const code = normalizeModuleCode(candidate.code);
+      if (!code || candidates.has(code)) {
+        continue;
+      }
+
+      candidates.set(code, candidate);
+    }
+
+    for (const event of result.events) {
+      const code = normalizeModuleCode(event.moduleCode);
+      if (!code || candidates.has(code)) {
+        continue;
+      }
+
+      candidates.set(code, {
+        code,
+        name: code,
+        metadata: {},
+        warnings: [],
+      });
+    }
+
+    return candidates;
+  }
+
+  private async createOrReuseModuleGrouping(
+    db: AppDatabase,
+    moduleIds: string[],
+  ): Promise<string> {
+    const sortedModuleIds = [...new Set(moduleIds)].sort();
+    const hash =
+      sortedModuleIds.length > 0 ? hashModuleIds(sortedModuleIds) : null;
+
+    if (hash) {
+      const [existingGroup] = await db
+        .select()
+        .from(ModuleGrouping)
+        .where(eq(ModuleGrouping.Hash, hash))
+        .limit(1);
+
+      if (existingGroup) {
+        return existingGroup.GroupID;
+      }
+    }
+
+    const [group] = await db
+      .insert(ModuleGrouping)
+      .values(hash ? { Hash: hash } : {})
+      .returning();
+
+    if (!group) {
+      throw new ConflictException(
+        'PDF parser module grouping could not be created',
+      );
+    }
+
+    if (sortedModuleIds.length > 0) {
+      await db.insert(GroupModules).values(
+        sortedModuleIds.map((moduleId) => ({
+          GroupID: group.GroupID,
+          ModuleID: moduleId,
+        })),
+      );
+    }
+
+    return group.GroupID;
+  }
+}

--- a/apps/backend/src/pdf-parser/pdf-parse-submission.spec.ts
+++ b/apps/backend/src/pdf-parser/pdf-parse-submission.spec.ts
@@ -1,0 +1,253 @@
+import type { PdfStreamFingerprintResult } from 'shared-types';
+import { QueueProducerService } from '../jobs/queue-producer.service';
+import { ObjectStorageService } from '../storage/object-storage.service';
+import { PdfParseSubmission } from './pdf-parse-submission';
+import { PdfParserFingerprintService } from './pdf-parser-fingerprint.service';
+import {
+  PdfParserJobStoreService,
+  type PdfParserJobRecord,
+} from './pdf-parser-job-store.service';
+
+describe('PdfParseSubmission', () => {
+  let queueProducer: MockQueueProducer;
+  let storage: MockObjectStorage;
+  let jobStore: MockPdfParserJobStore;
+  let fingerprintService: MockPdfParserFingerprintService;
+  let submission: PdfParseSubmission;
+
+  beforeEach(() => {
+    queueProducer = { enqueuePdfParseJob: jest.fn().mockResolvedValue({}) };
+    storage = { putObject: jest.fn().mockResolvedValue({}) };
+    jobStore = {
+      findDuplicate: jest.fn().mockResolvedValue(undefined),
+      createQueuedJob: jest.fn().mockResolvedValue(queuedRecord),
+      retryFailedDuplicate: jest.fn().mockResolvedValue(retriedRecord),
+      markInfrastructureFailure: jest.fn().mockResolvedValue(undefined),
+    };
+    fingerprintService = {
+      computeOrThrow: jest.fn().mockReturnValue(fingerprint),
+    };
+
+    submission = new PdfParseSubmission(
+      queueProducer as unknown as QueueProducerService,
+      storage as unknown as ObjectStorageService,
+      jobStore as unknown as PdfParserJobStoreService,
+      fingerprintService as unknown as PdfParserFingerprintService,
+    );
+  });
+
+  it('recomputes the backend hash and keeps a mismatching client hash diagnostic only', async () => {
+    await submission.submit(submissionInput);
+
+    expect(jobStore.findDuplicate).toHaveBeenCalledWith({
+      userId,
+      universityId,
+      adapterKey: 'up',
+      fingerprintAlgorithm: fingerprint.algorithmVersion,
+      pdfStreamHash: fingerprint.hash,
+      statuses: ['queued', 'completed'],
+    });
+    expect(jobStore.createQueuedJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId,
+        universityId,
+        clientPdfStreamHash: 'f'.repeat(64),
+        pdfStreamHash: fingerprint.hash,
+        streamCount: fingerprint.streamCount,
+      }),
+    );
+  });
+
+  it('returns an existing duplicate upload without storing or enqueueing another job', async () => {
+    jobStore.findDuplicate.mockResolvedValue(completedRecord);
+
+    await expect(submission.submit(submissionInput)).resolves.toEqual({
+      jobId: completedRecord.jobId,
+      fileKey: completedRecord.fileKey,
+      adapterKey: completedRecord.adapterKey,
+      status: completedRecord.status,
+      result: completedRecord.result,
+      error: completedRecord.error,
+      moduleGroupingId: completedRecord.moduleGroupingId,
+      createdAt: completedRecord.createdAt,
+      updatedAt: completedRecord.updatedAt,
+      statusUrl: `/pdf-parser/jobs/${completedRecord.jobId}`,
+    });
+
+    expect(storage.putObject).not.toHaveBeenCalled();
+    expect(jobStore.createQueuedJob).not.toHaveBeenCalled();
+    expect(queueProducer.enqueuePdfParseJob).not.toHaveBeenCalled();
+  });
+
+  it('creates the persisted job before enqueueing the BullMQ job', async () => {
+    const calls: string[] = [];
+    jobStore.createQueuedJob.mockImplementation(async () => {
+      calls.push('create');
+      return queuedRecord;
+    });
+    storage.putObject.mockImplementation(async () => {
+      calls.push('store');
+      return {};
+    });
+    queueProducer.enqueuePdfParseJob.mockImplementation(async () => {
+      calls.push('enqueue');
+      return {};
+    });
+
+    await submission.submit(submissionInput);
+
+    expect(calls).toEqual(['create', 'store', 'enqueue']);
+  });
+
+  it('retries a failed duplicate upload instead of returning the failed job', async () => {
+    jobStore.createQueuedJob.mockRejectedValue(new Error('duplicate key'));
+    jobStore.findDuplicate
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(failedRecord);
+
+    await expect(submission.submit(submissionInput)).resolves.toEqual(
+      expect.objectContaining({
+        jobId: retriedRecord.jobId,
+        status: 'queued',
+      }),
+    );
+
+    expect(jobStore.retryFailedDuplicate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: failedRecord.jobId,
+        adapterKey: 'up',
+        pdfStreamHash,
+      }),
+    );
+    expect(storage.putObject).toHaveBeenCalledWith(
+      expect.objectContaining({ key: retriedRecord.fileKey }),
+    );
+    expect(queueProducer.enqueuePdfParseJob).toHaveBeenCalledWith({
+      jobId: retriedRecord.jobId,
+      fileKey: retriedRecord.fileKey,
+      adapterKey: 'up',
+    });
+  });
+
+  it('marks the reserved job failed when object storage fails', async () => {
+    storage.putObject.mockRejectedValue(new Error('storage down'));
+
+    await expect(submission.submit(submissionInput)).rejects.toThrow(
+      'PDF parser upload could not be stored',
+    );
+
+    expect(jobStore.markInfrastructureFailure).toHaveBeenCalledWith(
+      queuedRecord.jobId,
+      expect.objectContaining({
+        code: 'PDF_PARSE_UPLOAD_FAILED',
+      }),
+    );
+    expect(queueProducer.enqueuePdfParseJob).not.toHaveBeenCalled();
+  });
+
+  it('marks the persisted job failed when enqueueing fails', async () => {
+    queueProducer.enqueuePdfParseJob.mockRejectedValue(new Error('redis down'));
+
+    await expect(submission.submit(submissionInput)).rejects.toThrow(
+      'PDF parser job could not be enqueued',
+    );
+
+    expect(jobStore.markInfrastructureFailure).toHaveBeenCalledWith(
+      expect.stringMatching(/^pdf-parse-/),
+      expect.objectContaining({
+        code: 'PDF_PARSE_ENQUEUE_FAILED',
+      }),
+    );
+  });
+});
+
+const userId = '11111111-1111-4111-8111-111111111111';
+const universityId = '22222222-2222-4222-8222-222222222222';
+const pdfStreamHash = 'a'.repeat(64);
+
+type MockQueueProducer = {
+  enqueuePdfParseJob: jest.Mock;
+};
+
+type MockObjectStorage = {
+  putObject: jest.Mock;
+};
+
+type MockPdfParserJobStore = {
+  findDuplicate: jest.Mock;
+  createQueuedJob: jest.Mock;
+  retryFailedDuplicate: jest.Mock;
+  markInfrastructureFailure: jest.Mock;
+};
+
+type MockPdfParserFingerprintService = {
+  computeOrThrow: jest.Mock;
+};
+
+const fingerprint: Extract<PdfStreamFingerprintResult, { ok: true }> = {
+  ok: true,
+  hash: pdfStreamHash,
+  streamCount: 1,
+  algorithmVersion: 'pdf-stream-payload-sha256-v1',
+};
+
+const uploadedPdf = {
+  originalName: 'Timetable PDF.pdf',
+  mimetype: 'application/pdf',
+  buffer: Buffer.from(
+    '%PDF-1.7\n1 0 obj\n<< /Length 7 >>\nstream\npayload\nendstream\nendobj\n',
+  ),
+};
+
+const submissionInput = {
+  userId,
+  universityId,
+  adapterKey: 'up',
+  clientPdfStreamHash: 'f'.repeat(64),
+  file: uploadedPdf,
+};
+
+const queuedRecord: PdfParserJobRecord = {
+  jobId: 'pdf-parse-33333333-3333-4333-8333-333333333333',
+  fileKey:
+    'uploads/pdf-parser/pdf-parse-33333333-3333-4333-8333-333333333333/timetable-pdf.pdf',
+  adapterKey: 'up',
+  status: 'queued',
+  createdAt: '2026-07-03T00:00:00.000Z',
+  updatedAt: '2026-07-03T00:00:00.000Z',
+};
+
+const completedRecord: PdfParserJobRecord = {
+  jobId: queuedRecord.jobId,
+  fileKey: queuedRecord.fileKey,
+  adapterKey: queuedRecord.adapterKey,
+  status: 'completed',
+  result: { modules: [], events: [], warnings: [] },
+  createdAt: queuedRecord.createdAt,
+  updatedAt: queuedRecord.updatedAt,
+};
+
+const failedRecord: PdfParserJobRecord = {
+  jobId: 'pdf-parse-44444444-4444-4444-8444-444444444444',
+  fileKey:
+    'uploads/pdf-parser/pdf-parse-44444444-4444-4444-8444-444444444444/timetable-pdf.pdf',
+  adapterKey: 'up',
+  status: 'failed',
+  error: {
+    code: 'PARSER_FAILED',
+    message: 'Parser failed',
+    details: {},
+  },
+  createdAt: queuedRecord.createdAt,
+  updatedAt: queuedRecord.updatedAt,
+};
+
+const retriedRecord: PdfParserJobRecord = {
+  jobId: failedRecord.jobId,
+  fileKey:
+    'uploads/pdf-parser/pdf-parse-55555555-5555-4555-8555-555555555555/timetable-pdf.pdf',
+  adapterKey: 'up',
+  status: 'queued',
+  createdAt: failedRecord.createdAt,
+  updatedAt: failedRecord.updatedAt,
+};

--- a/apps/backend/src/pdf-parser/pdf-parse-submission.ts
+++ b/apps/backend/src/pdf-parser/pdf-parse-submission.ts
@@ -1,0 +1,212 @@
+import { InternalServerErrorException, Injectable } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { QueueProducerService } from '../jobs/queue-producer.service';
+import { ObjectStorageService } from '../storage/object-storage.service';
+import { PdfParserUploadResponseDto } from './dto/pdf-parser-job-response.dto';
+import { PdfParserFingerprintService } from './pdf-parser-fingerprint.service';
+import {
+  PdfParserJobStoreService,
+  type PdfParserJobRecord,
+} from './pdf-parser-job-store.service';
+
+export interface PdfParseSubmissionInput {
+  userId: string;
+  universityId: string;
+  adapterKey: string;
+  clientPdfStreamHash?: string;
+  file: PdfParseSubmissionFile;
+}
+
+export interface PdfParseSubmissionFile {
+  originalName: string;
+  mimetype: string;
+  buffer: Buffer;
+}
+
+@Injectable()
+export class PdfParseSubmission {
+  constructor(
+    private readonly queueProducer: QueueProducerService,
+    private readonly storage: ObjectStorageService,
+    private readonly jobStore: PdfParserJobStoreService,
+    private readonly fingerprintService: PdfParserFingerprintService,
+  ) {}
+
+  async submit(
+    input: PdfParseSubmissionInput,
+  ): Promise<PdfParserUploadResponseDto> {
+    const fingerprint = this.fingerprintService.computeOrThrow(
+      input.file.buffer,
+    );
+
+    const duplicate = await this.jobStore.findDuplicate({
+      userId: input.userId,
+      universityId: input.universityId,
+      adapterKey: input.adapterKey,
+      fingerprintAlgorithm: fingerprint.algorithmVersion,
+      pdfStreamHash: fingerprint.hash,
+      statuses: ['queued', 'completed'],
+    });
+
+    if (duplicate) {
+      return toUploadResponse(duplicate);
+    }
+
+    const jobId = `pdf-parse-${randomUUID()}`;
+    const fileKey = buildFileKey(jobId, input.file.originalName);
+    const preparedJob = await this.prepareUploadJob({
+      jobId,
+      userId: input.userId,
+      universityId: input.universityId,
+      fileKey,
+      adapterKey: input.adapterKey,
+      clientPdfStreamHash: input.clientPdfStreamHash,
+      pdfStreamHash: fingerprint.hash,
+      fingerprintAlgorithm: fingerprint.algorithmVersion,
+      streamCount: fingerprint.streamCount,
+    });
+
+    if (preparedJob.kind === 'existing') {
+      return toUploadResponse(preparedJob.record);
+    }
+
+    const record = preparedJob.record;
+    const storageFileKey = record.fileKey ?? fileKey;
+
+    await this.storeUploadedPdf(record.jobId, storageFileKey, input.file);
+    await this.enqueueJob(record.jobId, storageFileKey, input.adapterKey);
+
+    return toUploadResponse(record);
+  }
+
+  private async prepareUploadJob(
+    input: PrepareUploadJobInput,
+  ): Promise<PreparedUploadJob> {
+    try {
+      const record = await this.jobStore.createQueuedJob(input);
+
+      return { kind: 'pending', record };
+    } catch (error) {
+      const duplicate = await this.jobStore.findDuplicate({
+        userId: input.userId,
+        universityId: input.universityId,
+        adapterKey: input.adapterKey,
+        fingerprintAlgorithm: input.fingerprintAlgorithm,
+        pdfStreamHash: input.pdfStreamHash,
+      });
+
+      if (!duplicate) {
+        throw error;
+      }
+
+      if (duplicate.status !== 'failed') {
+        return { kind: 'existing', record: duplicate };
+      }
+
+      const retriedRecord = await this.jobStore.retryFailedDuplicate({
+        jobId: duplicate.jobId,
+        fileKey: input.fileKey,
+        adapterKey: input.adapterKey,
+        clientPdfStreamHash: input.clientPdfStreamHash,
+        pdfStreamHash: input.pdfStreamHash,
+        fingerprintAlgorithm: input.fingerprintAlgorithm,
+        streamCount: input.streamCount,
+      });
+
+      return { kind: 'pending', record: retriedRecord };
+    }
+  }
+
+  private async storeUploadedPdf(
+    jobId: string,
+    fileKey: string,
+    file: PdfParseSubmissionFile,
+  ): Promise<void> {
+    try {
+      await this.storage.putObject({
+        key: fileKey,
+        body: file.buffer,
+        contentType: file.mimetype || 'application/pdf',
+      });
+    } catch (error) {
+      await this.jobStore.markInfrastructureFailure(jobId, {
+        code: 'PDF_PARSE_UPLOAD_FAILED',
+        message: 'PDF parser upload could not be stored',
+        details: {
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      });
+      throw new InternalServerErrorException(
+        'PDF parser upload could not be stored',
+      );
+    }
+  }
+
+  private async enqueueJob(
+    jobId: string,
+    fileKey: string,
+    adapterKey: string,
+  ): Promise<void> {
+    try {
+      await this.queueProducer.enqueuePdfParseJob({
+        jobId,
+        fileKey,
+        adapterKey,
+      });
+    } catch (error) {
+      await this.jobStore.markInfrastructureFailure(jobId, {
+        code: 'PDF_PARSE_ENQUEUE_FAILED',
+        message: 'PDF parser job could not be enqueued',
+        details: {
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      });
+      throw new InternalServerErrorException(
+        'PDF parser job could not be enqueued',
+      );
+    }
+  }
+}
+
+interface PrepareUploadJobInput {
+  jobId: string;
+  userId: string;
+  universityId: string;
+  fileKey: string;
+  adapterKey: string;
+  clientPdfStreamHash?: string;
+  pdfStreamHash: string;
+  fingerprintAlgorithm: string;
+  streamCount: number;
+}
+
+type PreparedUploadJob =
+  | { kind: 'pending'; record: PdfParserJobRecord }
+  | { kind: 'existing'; record: PdfParserJobRecord };
+
+function toUploadResponse(
+  record: PdfParserJobRecord,
+): PdfParserUploadResponseDto {
+  return {
+    jobId: record.jobId,
+    fileKey: record.fileKey,
+    adapterKey: record.adapterKey,
+    status: record.status,
+    result: record.result,
+    error: record.error,
+    moduleGroupingId: record.moduleGroupingId,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    statusUrl: `/pdf-parser/jobs/${record.jobId}`,
+  };
+}
+
+function buildFileKey(jobId: string, originalName: string): string {
+  const safeName = originalName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return `uploads/pdf-parser/${jobId}/${safeName || 'input.pdf'}`;
+}

--- a/apps/backend/src/pdf-parser/pdf-parse-submission.ts
+++ b/apps/backend/src/pdf-parser/pdf-parse-submission.ts
@@ -202,11 +202,52 @@ function toUploadResponse(
 }
 
 function buildFileKey(jobId: string, originalName: string): string {
-  const safeName = originalName
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9.-]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  const dashedName = toDashedFileName(originalName.trim().toLowerCase());
+  const safeName = trimBoundaryDashes(dashedName);
 
   return `uploads/pdf-parser/${jobId}/${safeName || 'input.pdf'}`;
+}
+
+function toDashedFileName(value: string): string {
+  let output = '';
+  let lastWasDash = false;
+
+  for (const character of value) {
+    if (isSafeFileNameCharacter(character)) {
+      output += character;
+      lastWasDash = false;
+      continue;
+    }
+
+    if (!lastWasDash) {
+      output += '-';
+      lastWasDash = true;
+    }
+  }
+
+  return output;
+}
+
+function isSafeFileNameCharacter(character: string): boolean {
+  return (
+    (character >= 'a' && character <= 'z') ||
+    (character >= '0' && character <= '9') ||
+    character === '.' ||
+    character === '-'
+  );
+}
+
+function trimBoundaryDashes(value: string): string {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value[start] === '-') {
+    start += 1;
+  }
+
+  while (end > start && value[end - 1] === '-') {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
 }

--- a/apps/backend/src/pdf-parser/pdf-parser-fingerprint.service.spec.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser-fingerprint.service.spec.ts
@@ -9,7 +9,7 @@ describe('PdfParserFingerprintService', () => {
     (lineEnding) => {
       const result = service.compute(
         bytes(
-          `1 0 obj${lineEnding}stream${lineEnding}payload${lineEnding}endstream`,
+          `1 0 obj${lineEnding}<< /Length 7 >>${lineEnding}stream${lineEnding}payload${lineEnding}endstream${lineEnding}endobj`,
         ),
       );
 
@@ -24,7 +24,9 @@ describe('PdfParserFingerprintService', () => {
 
   it('hashes multiple streams in file order with length separators', () => {
     const result = service.compute(
-      bytes('stream\nab\nendstream stream\nc\nendstream'),
+      bytes(
+        '%PDF-1.7\n1 0 obj\n<< /Length 2 >>\nstream\nab\nendstream\nendobj\n2 0 obj\n<< /Length 1 >>\nstream\nc\nendstream\nendobj\n',
+      ),
     );
 
     expect(result).toMatchObject({
@@ -38,12 +40,12 @@ describe('PdfParserFingerprintService', () => {
   it('ignores changes outside stream payloads', () => {
     const first = service.compute(
       bytes(
-        'stream\npayload\nendstream trailer <</ID [<one>]>> /CreationDate (A)',
+        '%PDF-1.7\n1 0 obj\n<< /Length 7 >>\nstream\npayload\nendstream\nendobj\ntrailer <</ID [<one>]>> /CreationDate (A)',
       ),
     );
     const second = service.compute(
       bytes(
-        'stream\npayload\nendstream trailer <</ID [<two>]>> /CreationDate (B)',
+        '%PDF-1.7\n1 0 obj\n<< /Length 7 >>\nstream\npayload\nendstream\nendobj\ntrailer <</ID [<two>]>> /CreationDate (B)',
       ),
     );
 
@@ -51,8 +53,16 @@ describe('PdfParserFingerprintService', () => {
   });
 
   it('changes when stream payload bytes change', () => {
-    const first = service.compute(bytes('stream\npayload\nendstream'));
-    const second = service.compute(bytes('stream\nchanged\nendstream'));
+    const first = service.compute(
+      bytes(
+        '%PDF-1.7\n1 0 obj\n<< /Length 7 >>\nstream\npayload\nendstream\nendobj\n',
+      ),
+    );
+    const second = service.compute(
+      bytes(
+        '%PDF-1.7\n1 0 obj\n<< /Length 7 >>\nstream\nchanged\nendstream\nendobj\n',
+      ),
+    );
 
     expect(first.ok && first.hash).not.toBe(second.ok && second.hash);
   });

--- a/apps/backend/src/pdf-parser/pdf-parser-fingerprint.service.spec.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser-fingerprint.service.spec.ts
@@ -1,0 +1,89 @@
+import { createHash } from 'node:crypto';
+import { PdfParserFingerprintService } from './pdf-parser-fingerprint.service';
+
+describe('PdfParserFingerprintService', () => {
+  const service = new PdfParserFingerprintService();
+
+  it.each(['\r\n', '\n', '\r'])(
+    'hashes stream payloads with %j line endings',
+    (lineEnding) => {
+      const result = service.compute(
+        bytes(
+          `1 0 obj${lineEnding}stream${lineEnding}payload${lineEnding}endstream`,
+        ),
+      );
+
+      expect(result).toEqual({
+        ok: true,
+        hash: expectedHash(['payload']),
+        streamCount: 1,
+        algorithmVersion: 'pdf-stream-payload-sha256-v1',
+      });
+    },
+  );
+
+  it('hashes multiple streams in file order with length separators', () => {
+    const result = service.compute(
+      bytes('stream\nab\nendstream stream\nc\nendstream'),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      hash: expectedHash(['ab', 'c']),
+      streamCount: 2,
+    });
+    expect(expectedHash(['ab', 'c'])).not.toBe(expectedHash(['a', 'bc']));
+  });
+
+  it('ignores changes outside stream payloads', () => {
+    const first = service.compute(
+      bytes(
+        'stream\npayload\nendstream trailer <</ID [<one>]>> /CreationDate (A)',
+      ),
+    );
+    const second = service.compute(
+      bytes(
+        'stream\npayload\nendstream trailer <</ID [<two>]>> /CreationDate (B)',
+      ),
+    );
+
+    expect(first.ok && first.hash).toBe(second.ok && second.hash);
+  });
+
+  it('changes when stream payload bytes change', () => {
+    const first = service.compute(bytes('stream\npayload\nendstream'));
+    const second = service.compute(bytes('stream\nchanged\nendstream'));
+
+    expect(first.ok && first.hash).not.toBe(second.ok && second.hash);
+  });
+
+  it('returns a structured failure when no streams are found', () => {
+    expect(service.compute(bytes('%PDF-1.7 no stream payloads'))).toEqual({
+      ok: false,
+      streamCount: 0,
+      algorithmVersion: 'pdf-stream-payload-sha256-v1',
+      reason: 'NO_STREAMS_FOUND',
+    });
+  });
+});
+
+function bytes(value: string): Buffer {
+  return Buffer.from(value, 'utf8');
+}
+
+function expectedHash(payloads: string[]): string {
+  const hash = createHash('sha256');
+  for (const payload of payloads) {
+    const payloadBytes = bytes(payload);
+    hash.update(encodeUint64BigEndian(payloadBytes.byteLength));
+    hash.update(payloadBytes);
+  }
+
+  return hash.digest('hex');
+}
+
+function encodeUint64BigEndian(value: number): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64BE(BigInt(value));
+  return buffer;
+}

--- a/apps/backend/src/pdf-parser/pdf-parser-fingerprint.service.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser-fingerprint.service.ts
@@ -1,0 +1,39 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import {
+  computePdfStreamFingerprint,
+  type PdfStreamFingerprintResult,
+  type Sha256Hash,
+} from 'shared-types';
+
+@Injectable()
+export class PdfParserFingerprintService {
+  compute(buffer: Buffer | Uint8Array): PdfStreamFingerprintResult {
+    return computePdfStreamFingerprint(buffer, createNodeSha256Hash());
+  }
+
+  computeOrThrow(
+    buffer: Buffer | Uint8Array,
+  ): Extract<PdfStreamFingerprintResult, { ok: true }> {
+    const fingerprint = this.compute(buffer);
+    if (!fingerprint.ok) {
+      throw new BadRequestException(
+        'Uploaded PDF does not contain stream payloads that can be fingerprinted',
+      );
+    }
+
+    return fingerprint;
+  }
+}
+
+function createNodeSha256Hash(): Sha256Hash {
+  const hash = createHash('sha256');
+  return {
+    update(input) {
+      hash.update(input);
+    },
+    digestHex() {
+      return hash.digest('hex');
+    },
+  };
+}

--- a/apps/backend/src/pdf-parser/pdf-parser-import.utils.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser-import.utils.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto';
+
+export function normalizeModuleCode(code: string): string {
+  return truncateForColumn(code.trim().toUpperCase(), 10);
+}
+
+export function truncateForColumn(value: string, maxLength: number): string {
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+export function hashModuleIds(moduleIds: string[]): string {
+  return createHash('sha256')
+    .update(JSON.stringify(moduleIds))
+    .digest('base64');
+}

--- a/apps/backend/src/pdf-parser/pdf-parser-job-store.service.int.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser-job-store.service.int.ts
@@ -1,11 +1,17 @@
+import { ConfigService } from '@nestjs/config';
 import { migrate as migratePglite } from 'drizzle-orm/pglite/migrator';
+import type { PgliteDatabase } from 'drizzle-orm/pglite';
 import { eq } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
+import type { PdfParserResult } from 'shared-types';
+import type * as schema from '../db/schema';
 import { DatabaseService } from '../db/database.service';
 import {
   Event,
   EventVenue,
   GroupModules,
+  ModuleGrouping,
   University,
   UniversityEvent,
   Venue,
@@ -13,6 +19,7 @@ import {
   parseJob,
   usersTable,
 } from '../entities';
+import { EventImportKeyService } from '../Events/event-import-key.service';
 import { EventImporter } from './event-importer.service';
 import { ModuleResolver } from './module-resolver.service';
 import { ParserResultImporter } from './parser-result-importer.service';
@@ -23,17 +30,20 @@ describe('PdfParserJobStoreService', () => {
   let service: PdfParserJobStoreService;
 
   beforeEach(async () => {
-    databaseService = new DatabaseService({
-      get: (key: string) => (key === 'DB_MODE' ? 'PGLITE' : undefined),
-    } as never);
+    databaseService = new DatabaseService(
+      new ConfigService({ DB_MODE: 'PGLITE' }),
+    );
 
-    await migratePglite(databaseService.db as never, {
+    await migratePglite(toPgliteDatabase(databaseService), {
       migrationsFolder: join(process.cwd(), 'drizzle'),
     });
 
     service = new PdfParserJobStoreService(
       databaseService,
-      new ParserResultImporter(new ModuleResolver(), new EventImporter()),
+      new ParserResultImporter(
+        new ModuleResolver(),
+        new EventImporter(new EventImportKeyService()),
+      ),
     );
 
     await databaseService.db.insert(usersTable).values({
@@ -101,7 +111,7 @@ describe('PdfParserJobStoreService', () => {
     });
 
     expect(record.status).toBe('completed');
-    expect(record.moduleGroupingId).toEqual(expect.any(String));
+    expect(typeof record.moduleGroupingId).toBe('string');
 
     const [storedJob] = await databaseService.db
       .select()
@@ -248,9 +258,151 @@ describe('PdfParserJobStoreService', () => {
       }),
     ).resolves.toMatchObject({ status: 'completed' });
   });
+
+  it('reuses imported module, event, and venue rows across parser jobs', async () => {
+    await service.createQueuedJob({
+      jobId,
+      userId,
+      universityId,
+      fileKey: 'uploads/pdf-parser/input-a.pdf',
+      adapterKey: 'up',
+      pdfStreamHash: 'd'.repeat(64),
+      fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+      streamCount: 1,
+    });
+    await service.createQueuedJob({
+      jobId: secondJobId,
+      userId,
+      universityId,
+      fileKey: 'uploads/pdf-parser/input-b.pdf',
+      adapterKey: 'up',
+      pdfStreamHash: 'e'.repeat(64),
+      fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+      streamCount: 1,
+    });
+
+    await service.recordCallback(jobId, {
+      status: 'completed',
+      result: duplicateImportResult,
+    });
+    await service.recordCallback(secondJobId, {
+      status: 'completed',
+      result: duplicateImportResult,
+    });
+
+    const storedModules = await databaseService.db
+      .select()
+      .from(modules)
+      .where(eq(modules.moduleCode, 'COS103'));
+    const storedEvents = await databaseService.db.select().from(Event);
+    const storedVenues = await databaseService.db
+      .select()
+      .from(Venue)
+      .where(eq(Venue.VenueName, 'IT 4-5'));
+
+    expect(storedModules).toHaveLength(1);
+    expect(storedEvents).toHaveLength(1);
+    expect(storedVenues).toHaveLength(1);
+  });
+
+  it('rejects a module grouping hash whose GroupModules membership is incomplete', async () => {
+    const [module] = await databaseService.db
+      .insert(modules)
+      .values({
+        moduleID: corruptModuleId,
+        moduleCode: 'COS104',
+        moduleName: 'Computer Science 104',
+        validated: false,
+      })
+      .returning();
+    await databaseService.db.insert(ModuleGrouping).values({
+      GroupID: corruptGroupId,
+      Hash: hashModuleIds([module.moduleID]),
+    });
+    await service.createQueuedJob({
+      jobId,
+      userId,
+      universityId,
+      fileKey: 'uploads/pdf-parser/input.pdf',
+      adapterKey: 'up',
+      pdfStreamHash: 'f'.repeat(64),
+      fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+      streamCount: 1,
+    });
+
+    await expect(
+      service.recordCallback(jobId, {
+        status: 'completed',
+        result: {
+          modules: [
+            {
+              code: 'cos104',
+              name: 'Computer Science 104',
+              metadata: {},
+              warnings: [],
+            },
+          ],
+          events: [],
+          warnings: [],
+        },
+      }),
+    ).rejects.toThrow(
+      'PDF parser module grouping hash does not match group membership',
+    );
+  });
 });
 
 const userId = '11111111-1111-4111-8111-111111111111';
 const universityId = '22222222-2222-4222-8222-222222222222';
 const publicJobUuid = '33333333-3333-4333-8333-333333333333';
 const jobId = `pdf-parse-${publicJobUuid}`;
+const secondPublicJobUuid = '44444444-4444-4444-8444-444444444444';
+const secondJobId = `pdf-parse-${secondPublicJobUuid}`;
+const corruptModuleId = '55555555-5555-4555-8555-555555555555';
+const corruptGroupId = '66666666-6666-4666-8666-666666666666';
+
+const duplicateImportResult: PdfParserResult = {
+  modules: [
+    {
+      code: 'cos103',
+      name: 'Computer Science 103',
+      metadata: {},
+      warnings: [],
+    },
+  ],
+  events: [
+    {
+      moduleCode: 'cos103',
+      type: 'lecture',
+      sectionLabel: 'L1',
+      title: 'COS103 Lecture',
+      day: 'Tuesday',
+      date: null,
+      startTime: '10:30',
+      endTime: '11:20',
+      venues: ['IT 4-5'],
+      isRecurring: true,
+      metadata: {},
+      warnings: [],
+    },
+  ],
+  warnings: [],
+};
+
+function toPgliteDatabase(
+  databaseService: DatabaseService,
+): PgliteDatabase<typeof schema> {
+  if (!databaseService.pglite) {
+    throw new Error(
+      'Expected PGLite database service for parser integration test',
+    );
+  }
+
+  return databaseService.db;
+}
+
+function hashModuleIds(moduleIds: string[]): string {
+  return createHash('sha256')
+    .update(JSON.stringify(moduleIds))
+    .digest('base64');
+}

--- a/apps/backend/src/pdf-parser/pdf-parser-job-store.service.int.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser-job-store.service.int.ts
@@ -1,0 +1,256 @@
+import { migrate as migratePglite } from 'drizzle-orm/pglite/migrator';
+import { eq } from 'drizzle-orm';
+import { join } from 'node:path';
+import { DatabaseService } from '../db/database.service';
+import {
+  Event,
+  EventVenue,
+  GroupModules,
+  University,
+  UniversityEvent,
+  Venue,
+  modules,
+  parseJob,
+  usersTable,
+} from '../entities';
+import { EventImporter } from './event-importer.service';
+import { ModuleResolver } from './module-resolver.service';
+import { ParserResultImporter } from './parser-result-importer.service';
+import { PdfParserJobStoreService } from './pdf-parser-job-store.service';
+
+describe('PdfParserJobStoreService', () => {
+  let databaseService: DatabaseService;
+  let service: PdfParserJobStoreService;
+
+  beforeEach(async () => {
+    databaseService = new DatabaseService({
+      get: (key: string) => (key === 'DB_MODE' ? 'PGLITE' : undefined),
+    } as never);
+
+    await migratePglite(databaseService.db as never, {
+      migrationsFolder: join(process.cwd(), 'drizzle'),
+    });
+
+    service = new PdfParserJobStoreService(
+      databaseService,
+      new ParserResultImporter(new ModuleResolver(), new EventImporter()),
+    );
+
+    await databaseService.db.insert(usersTable).values({
+      id: userId,
+      name: 'Parser User',
+      email: 'parser-user@example.com',
+      emailVerified: true,
+      role: 'student',
+      banned: false,
+      createdAt: new Date('2026-07-03T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-03T00:00:00.000Z'),
+    });
+
+    await databaseService.db.insert(University).values({
+      UniversityID: universityId,
+      UniversityName: 'UP',
+    });
+  });
+
+  afterEach(async () => {
+    await databaseService.onModuleDestroy();
+  });
+
+  it('links completed parser jobs to a module grouping and creates unvalidated domain records', async () => {
+    await service.createQueuedJob({
+      jobId,
+      userId,
+      universityId,
+      fileKey: 'uploads/pdf-parser/input.pdf',
+      adapterKey: 'up',
+      pdfStreamHash: 'a'.repeat(64),
+      fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+      streamCount: 1,
+    });
+
+    const record = await service.recordCallback(jobId, {
+      status: 'completed',
+      result: {
+        modules: [
+          {
+            code: 'cos101',
+            name: 'Computer Science 101',
+            metadata: { source: 'pdf' },
+            warnings: [],
+          },
+        ],
+        events: [
+          {
+            moduleCode: 'cos101',
+            type: 'lecture',
+            sectionLabel: 'L1',
+            title: 'COS101 Lecture',
+            day: 'Monday',
+            date: null,
+            startTime: '08:30',
+            endTime: '09:20',
+            venues: ['IT 2-26'],
+            isRecurring: true,
+            metadata: {},
+            warnings: [],
+          },
+        ],
+        warnings: [],
+      },
+    });
+
+    expect(record.status).toBe('completed');
+    expect(record.moduleGroupingId).toEqual(expect.any(String));
+
+    const [storedJob] = await databaseService.db
+      .select()
+      .from(parseJob)
+      .where(eq(parseJob.JobID, publicJobUuid));
+    expect(storedJob.GroupID).toBe(record.moduleGroupingId);
+
+    const [storedModule] = await databaseService.db
+      .select()
+      .from(modules)
+      .where(eq(modules.moduleCode, 'COS101'));
+    expect(storedModule).toMatchObject({
+      moduleCode: 'COS101',
+      moduleName: 'Computer Science 101',
+      validated: false,
+    });
+
+    const [groupModule] = await databaseService.db
+      .select()
+      .from(GroupModules)
+      .where(eq(GroupModules.GroupID, record.moduleGroupingId!));
+    expect(groupModule.ModuleID).toBe(storedModule.moduleID);
+
+    const [storedEvent] = await databaseService.db.select().from(Event);
+    expect(storedEvent).toMatchObject({
+      eventName: 'COS101 Lecture',
+      eventCode: 'L1',
+      isRecurring: true,
+      validated: false,
+    });
+    expect(storedEvent.eventCriteria).toMatchObject({
+      moduleID: storedModule.moduleID,
+      date: 'Monday',
+      startTime: '08:30',
+      endTime: '09:20',
+      venue: 'IT 2-26',
+    });
+
+    const [universityEvent] = await databaseService.db
+      .select()
+      .from(UniversityEvent)
+      .where(eq(UniversityEvent.eventID, storedEvent.eventID));
+    expect(universityEvent.moduleID).toBe(storedModule.moduleID);
+
+    const [venue] = await databaseService.db.select().from(Venue);
+    expect(venue).toMatchObject({
+      VenueName: 'IT 2-26',
+      UniversityID: universityId,
+    });
+
+    const [eventVenue] = await databaseService.db
+      .select()
+      .from(EventVenue)
+      .where(eq(EventVenue.EventID, storedEvent.eventID));
+    expect(eventVenue.VenueID).toBe(venue.VenueID);
+  });
+
+  it('does not return failed jobs when duplicate lookup is scoped to active statuses', async () => {
+    await service.createQueuedJob({
+      jobId,
+      userId,
+      universityId,
+      fileKey: 'uploads/pdf-parser/input.pdf',
+      adapterKey: 'up',
+      pdfStreamHash: 'b'.repeat(64),
+      fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+      streamCount: 1,
+    });
+
+    await service.markInfrastructureFailure(jobId, {
+      code: 'PARSER_FAILED',
+      message: 'Parser failed',
+      details: {},
+    });
+
+    await expect(
+      service.findDuplicate({
+        userId,
+        universityId,
+        adapterKey: 'up',
+        pdfStreamHash: 'b'.repeat(64),
+        fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+        statuses: ['queued', 'completed'],
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      service.findDuplicate({
+        userId,
+        universityId,
+        adapterKey: 'up',
+        pdfStreamHash: 'b'.repeat(64),
+        fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+      }),
+    ).resolves.toMatchObject({ status: 'failed' });
+  });
+
+  it('accepts equivalent completed callbacks with different JSON key order', async () => {
+    await service.createQueuedJob({
+      jobId,
+      userId,
+      universityId,
+      fileKey: 'uploads/pdf-parser/input.pdf',
+      adapterKey: 'up',
+      pdfStreamHash: 'c'.repeat(64),
+      fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+      streamCount: 1,
+    });
+
+    const firstResult = {
+      modules: [
+        {
+          code: 'cos102',
+          name: 'Computer Science 102',
+          metadata: { source: 'pdf', page: 1 },
+          warnings: [],
+        },
+      ],
+      events: [],
+      warnings: [],
+    };
+    const equivalentResult = {
+      modules: [
+        {
+          warnings: [],
+          metadata: { page: 1, source: 'pdf' },
+          name: 'Computer Science 102',
+          code: 'cos102',
+        },
+      ],
+      events: [],
+      warnings: [],
+    };
+
+    await service.recordCallback(jobId, {
+      status: 'completed',
+      result: firstResult,
+    });
+
+    await expect(
+      service.recordCallback(jobId, {
+        status: 'completed',
+        result: equivalentResult,
+      }),
+    ).resolves.toMatchObject({ status: 'completed' });
+  });
+});
+
+const userId = '11111111-1111-4111-8111-111111111111';
+const universityId = '22222222-2222-4222-8222-222222222222';
+const publicJobUuid = '33333333-3333-4333-8333-333333333333';
+const jobId = `pdf-parse-${publicJobUuid}`;

--- a/apps/backend/src/pdf-parser/pdf-parser-job-store.service.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser-job-store.service.ts
@@ -1,9 +1,18 @@
-import { Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { and, eq, inArray } from 'drizzle-orm';
+import { isDeepStrictEqual } from 'node:util';
 import type {
   PdfParserCallbackPayload,
   PdfParserResult,
   WorkerCallbackError,
 } from 'shared-types';
+import { DatabaseService } from '../db/database.service';
+import { parseJob, type ParseJob } from '../entities';
+import { ParserResultImporter } from './parser-result-importer.service';
 
 export type PdfParserJobStatus = 'queued' | 'completed' | 'failed';
 
@@ -14,58 +23,363 @@ export interface PdfParserJobRecord {
   status: PdfParserJobStatus;
   result?: PdfParserResult;
   error?: WorkerCallbackError;
+  moduleGroupingId?: string | null;
   createdAt: string;
   updatedAt: string;
 }
 
 @Injectable()
 export class PdfParserJobStoreService {
-  private readonly jobs = new Map<string, PdfParserJobRecord>();
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly parserResultImporter: ParserResultImporter,
+  ) {}
 
-  createQueuedJob(input: {
+  async findDuplicate(input: {
+    userId: string;
+    universityId: string;
+    adapterKey: string;
+    fingerprintAlgorithm: string;
+    pdfStreamHash: string;
+    statuses?: PdfParserJobStatus[];
+  }): Promise<PdfParserJobRecord | undefined> {
+    const filters = [
+      eq(parseJob.UserID, input.userId),
+      eq(parseJob.UniversityID, input.universityId),
+      eq(parseJob.AdapterKey, input.adapterKey),
+      eq(parseJob.FingerprintAlgorithm, input.fingerprintAlgorithm),
+      eq(parseJob.PdfStreamHash, input.pdfStreamHash),
+    ];
+
+    if (input.statuses && input.statuses.length > 0) {
+      filters.push(inArray(parseJob.Status, input.statuses));
+    }
+
+    const [row] = await this.databaseService.db
+      .select()
+      .from(parseJob)
+      .where(and(...filters))
+      .limit(1);
+
+    return row ? mapParseJob(row) : undefined;
+  }
+
+  async createQueuedJob(input: {
+    jobId: string;
+    userId: string;
+    universityId: string;
+    fileKey: string;
+    adapterKey: string;
+    clientPdfStreamHash?: string;
+    pdfStreamHash: string;
+    fingerprintAlgorithm: string;
+    streamCount: number;
+  }): Promise<PdfParserJobRecord> {
+    const jobUuid = parsePublicJobId(input.jobId);
+    const now = new Date();
+    const [row] = await this.databaseService.db
+      .insert(parseJob)
+      .values({
+        JobID: jobUuid,
+        UserID: input.userId,
+        UniversityID: input.universityId,
+        AdapterKey: input.adapterKey,
+        FileKey: input.fileKey,
+        ClientPdfStreamHash: input.clientPdfStreamHash,
+        PdfStreamHash: input.pdfStreamHash,
+        FingerprintAlgorithm: input.fingerprintAlgorithm,
+        StreamCount: input.streamCount,
+        Status: 'queued',
+        CreatedAt: now,
+        UpdatedAt: now,
+      })
+      .returning();
+
+    if (!row) {
+      throw new ConflictException('PDF parser job could not be created');
+    }
+
+    return mapParseJob(row);
+  }
+
+  async markInfrastructureFailure(
+    jobId: string,
+    error: WorkerCallbackError,
+  ): Promise<PdfParserJobRecord> {
+    const jobUuid = parsePublicJobId(jobId);
+    const now = new Date();
+    const [row] = await this.databaseService.db
+      .update(parseJob)
+      .set({
+        Status: 'failed',
+        ErrorCode: error.code,
+        ErrorMessage: error.message,
+        ErrorDetails: error.details,
+        UpdatedAt: now,
+        FailedAt: now,
+      })
+      .where(eq(parseJob.JobID, jobUuid))
+      .returning();
+
+    if (!row) {
+      throw new NotFoundException(`PDF parser job not found: ${jobId}`);
+    }
+
+    return mapParseJob(row);
+  }
+
+  async retryFailedDuplicate(input: {
     jobId: string;
     fileKey: string;
     adapterKey: string;
-  }): PdfParserJobRecord {
-    const existing = this.jobs.get(input.jobId);
-    const now = new Date().toISOString();
-    const record: PdfParserJobRecord = {
-      jobId: input.jobId,
-      fileKey: input.fileKey,
-      adapterKey: input.adapterKey,
-      status: existing?.status ?? 'queued',
-      result: existing?.result,
-      error: existing?.error,
-      createdAt: existing?.createdAt ?? now,
-      updatedAt: existing?.updatedAt ?? now,
-    };
+    clientPdfStreamHash?: string;
+    pdfStreamHash: string;
+    fingerprintAlgorithm: string;
+    streamCount: number;
+  }): Promise<PdfParserJobRecord> {
+    const jobUuid = parsePublicJobId(input.jobId);
+    const now = new Date();
+    const [row] = await this.databaseService.db
+      .update(parseJob)
+      .set({
+        FileKey: input.fileKey,
+        AdapterKey: input.adapterKey,
+        ClientPdfStreamHash: input.clientPdfStreamHash,
+        PdfStreamHash: input.pdfStreamHash,
+        FingerprintAlgorithm: input.fingerprintAlgorithm,
+        StreamCount: input.streamCount,
+        Status: 'queued',
+        Result: null,
+        ErrorCode: null,
+        ErrorMessage: null,
+        ErrorDetails: null,
+        GroupID: null,
+        UpdatedAt: now,
+        CompletedAt: null,
+        FailedAt: null,
+      })
+      .where(and(eq(parseJob.JobID, jobUuid), eq(parseJob.Status, 'failed')))
+      .returning();
 
-    this.jobs.set(input.jobId, record);
-    return record;
+    if (!row) {
+      throw new ConflictException(
+        `PDF parser job is not available for retry: ${input.jobId}`,
+      );
+    }
+
+    return mapParseJob(row);
   }
 
-  recordCallback(
+  async recordCallback(
     jobId: string,
     callback: PdfParserCallbackPayload,
-  ): PdfParserJobRecord {
-    const existing = this.jobs.get(jobId);
-    const now = new Date().toISOString();
-    const record: PdfParserJobRecord = {
-      jobId,
-      fileKey: existing?.fileKey ?? null,
-      adapterKey: existing?.adapterKey ?? null,
-      status: callback.status,
-      result: callback.result,
-      error: callback.error,
-      createdAt: existing?.createdAt ?? now,
-      updatedAt: now,
-    };
+  ): Promise<PdfParserJobRecord> {
+    const existing = await this.findPersistedJob(jobId);
+    if (!existing) {
+      throw new NotFoundException(`PDF parser job not found: ${jobId}`);
+    }
 
-    this.jobs.set(jobId, record);
-    return record;
+    if (existing.Status === callback.status) {
+      const existingRecord = mapParseJob(existing);
+      if (callbackMatchesExisting(existingRecord, callback)) {
+        if (
+          callback.status === 'completed' &&
+          callback.result &&
+          !existing.GroupID
+        ) {
+          const updated = await this.linkCompletedJobToDomainRecords(
+            existing,
+            callback.result,
+          );
+          return mapParseJob(updated);
+        }
+
+        return existingRecord;
+      }
+
+      throw new ConflictException(
+        `PDF parser job already has a different ${callback.status} callback`,
+      );
+    }
+
+    if (existing.Status === 'completed' || existing.Status === 'failed') {
+      throw new ConflictException(
+        `PDF parser job is already ${existing.Status}`,
+      );
+    }
+
+    const row = await this.databaseService.db.transaction(async (tx) => {
+      const now = new Date();
+      const moduleGroupingId =
+        callback.status === 'completed' && callback.result
+          ? await this.parserResultImporter.importResult(
+              tx,
+              existing,
+              callback.result,
+            )
+          : null;
+
+      const [updated] = await tx
+        .update(parseJob)
+        .set({
+          Status: callback.status,
+          Result: callback.result ?? null,
+          ErrorCode: callback.error?.code ?? null,
+          ErrorMessage: callback.error?.message ?? null,
+          ErrorDetails: callback.error?.details ?? null,
+          GroupID: moduleGroupingId ?? existing.GroupID ?? null,
+          UpdatedAt: now,
+          CompletedAt: callback.status === 'completed' ? now : null,
+          FailedAt: callback.status === 'failed' ? now : null,
+        })
+        .where(eq(parseJob.JobID, existing.JobID))
+        .returning();
+
+      return updated;
+    });
+
+    if (!row) {
+      throw new NotFoundException(`PDF parser job not found: ${jobId}`);
+    }
+
+    return mapParseJob(row);
   }
 
-  findJob(jobId: string): PdfParserJobRecord | undefined {
-    return this.jobs.get(jobId);
+  async findJob(
+    jobId: string,
+    userContext?: { userId: string },
+  ): Promise<PdfParserJobRecord | undefined> {
+    const jobUuid = parsePublicJobId(jobId);
+
+    if (userContext) {
+      const [row] = await this.databaseService.db
+        .select()
+        .from(parseJob)
+        .where(
+          and(
+            eq(parseJob.JobID, jobUuid),
+            eq(parseJob.UserID, userContext.userId),
+          ),
+        )
+        .limit(1);
+
+      return row ? mapParseJob(row) : undefined;
+    }
+
+    const [row] = await this.databaseService.db
+      .select()
+      .from(parseJob)
+      .where(eq(parseJob.JobID, jobUuid))
+      .limit(1);
+
+    return row ? mapParseJob(row) : undefined;
+  }
+
+  private async findPersistedJob(jobId: string): Promise<ParseJob | undefined> {
+    const jobUuid = parsePublicJobId(jobId);
+    const [row] = await this.databaseService.db
+      .select()
+      .from(parseJob)
+      .where(eq(parseJob.JobID, jobUuid))
+      .limit(1);
+
+    return row;
+  }
+
+  private async linkCompletedJobToDomainRecords(
+    existing: ParseJob,
+    result: PdfParserResult,
+  ): Promise<ParseJob> {
+    const row = await this.databaseService.db.transaction(async (tx) => {
+      const moduleGroupingId = await this.parserResultImporter.importResult(
+        tx,
+        existing,
+        result,
+      );
+      const [updated] = await tx
+        .update(parseJob)
+        .set({
+          GroupID: moduleGroupingId,
+          UpdatedAt: new Date(),
+        })
+        .where(eq(parseJob.JobID, existing.JobID))
+        .returning();
+
+      return updated;
+    });
+
+    if (!row) {
+      throw new NotFoundException(
+        `PDF parser job not found: ${toPublicJobId(existing.JobID)}`,
+      );
+    }
+
+    return row;
   }
 }
+
+export function parsePublicJobId(jobId: string): string {
+  const trimmed = jobId.trim();
+  const uuid = trimmed.startsWith('pdf-parse-')
+    ? trimmed.slice('pdf-parse-'.length)
+    : trimmed;
+
+  if (!UUID_PATTERN.test(uuid)) {
+    throw new NotFoundException(`PDF parser job not found: ${jobId}`);
+  }
+
+  return uuid;
+}
+
+export function toPublicJobId(jobId: string): string {
+  return jobId.startsWith('pdf-parse-') ? jobId : `pdf-parse-${jobId}`;
+}
+
+function mapParseJob(row: ParseJob): PdfParserJobRecord {
+  const error =
+    row.ErrorCode && row.ErrorMessage
+      ? {
+          code: row.ErrorCode,
+          message: row.ErrorMessage,
+          details: row.ErrorDetails ?? undefined,
+        }
+      : undefined;
+
+  return {
+    jobId: toPublicJobId(row.JobID),
+    fileKey: row.FileKey,
+    adapterKey: row.AdapterKey,
+    status: parseJobStatus(row.Status),
+    result: row.Result ?? undefined,
+    error,
+    moduleGroupingId: row.GroupID,
+    createdAt: row.CreatedAt.toISOString(),
+    updatedAt: row.UpdatedAt.toISOString(),
+  };
+}
+
+function callbackMatchesExisting(
+  existing: PdfParserJobRecord,
+  callback: PdfParserCallbackPayload,
+): boolean {
+  if (callback.status === 'completed') {
+    return isDeepStrictEqual(existing.result, callback.result);
+  }
+
+  return (
+    existing.error?.code === callback.error?.code &&
+    existing.error?.message === callback.error?.message &&
+    isDeepStrictEqual(existing.error?.details, callback.error?.details)
+  );
+}
+
+function parseJobStatus(status: string): PdfParserJobStatus {
+  if (status === 'queued' || status === 'completed' || status === 'failed') {
+    return status;
+  }
+
+  throw new ConflictException(`Unsupported PDF parser job status: ${status}`);
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/apps/backend/src/pdf-parser/pdf-parser-job-store.service.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser-job-store.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@nestjs/common';
+import type {
+  PdfParserCallbackPayload,
+  PdfParserResult,
+  WorkerCallbackError,
+} from 'shared-types';
+
+export type PdfParserJobStatus = 'queued' | 'completed' | 'failed';
+
+export interface PdfParserJobRecord {
+  jobId: string;
+  fileKey: string | null;
+  adapterKey: string | null;
+  status: PdfParserJobStatus;
+  result?: PdfParserResult;
+  error?: WorkerCallbackError;
+  createdAt: string;
+  updatedAt: string;
+}
+
+@Injectable()
+export class PdfParserJobStoreService {
+  private readonly jobs = new Map<string, PdfParserJobRecord>();
+
+  createQueuedJob(input: {
+    jobId: string;
+    fileKey: string;
+    adapterKey: string;
+  }): PdfParserJobRecord {
+    const existing = this.jobs.get(input.jobId);
+    const now = new Date().toISOString();
+    const record: PdfParserJobRecord = {
+      jobId: input.jobId,
+      fileKey: input.fileKey,
+      adapterKey: input.adapterKey,
+      status: existing?.status ?? 'queued',
+      result: existing?.result,
+      error: existing?.error,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: existing?.updatedAt ?? now,
+    };
+
+    this.jobs.set(input.jobId, record);
+    return record;
+  }
+
+  recordCallback(
+    jobId: string,
+    callback: PdfParserCallbackPayload,
+  ): PdfParserJobRecord {
+    const existing = this.jobs.get(jobId);
+    const now = new Date().toISOString();
+    const record: PdfParserJobRecord = {
+      jobId,
+      fileKey: existing?.fileKey ?? null,
+      adapterKey: existing?.adapterKey ?? null,
+      status: callback.status,
+      result: callback.result,
+      error: callback.error,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    this.jobs.set(jobId, record);
+    return record;
+  }
+
+  findJob(jobId: string): PdfParserJobRecord | undefined {
+    return this.jobs.get(jobId);
+  }
+}

--- a/apps/backend/src/pdf-parser/pdf-parser-job-store.service.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser-job-store.service.ts
@@ -10,7 +10,7 @@ import type {
   PdfParserResult,
   WorkerCallbackError,
 } from 'shared-types';
-import { DatabaseService } from '../db/database.service';
+import { DatabaseService, type AppDatabase } from '../db/database.service';
 import { parseJob, type ParseJob } from '../entities';
 import { ParserResultImporter } from './parser-result-importer.service';
 
@@ -43,22 +43,28 @@ export class PdfParserJobStoreService {
     pdfStreamHash: string;
     statuses?: PdfParserJobStatus[];
   }): Promise<PdfParserJobRecord | undefined> {
-    const filters = [
-      eq(parseJob.UserID, input.userId),
-      eq(parseJob.UniversityID, input.universityId),
-      eq(parseJob.AdapterKey, input.adapterKey),
-      eq(parseJob.FingerprintAlgorithm, input.fingerprintAlgorithm),
-      eq(parseJob.PdfStreamHash, input.pdfStreamHash),
-    ];
-
-    if (input.statuses && input.statuses.length > 0) {
-      filters.push(inArray(parseJob.Status, input.statuses));
-    }
+    const duplicateCriteria =
+      input.statuses && input.statuses.length > 0
+        ? and(
+            eq(parseJob.UserID, input.userId),
+            eq(parseJob.UniversityID, input.universityId),
+            eq(parseJob.AdapterKey, input.adapterKey),
+            eq(parseJob.FingerprintAlgorithm, input.fingerprintAlgorithm),
+            eq(parseJob.PdfStreamHash, input.pdfStreamHash),
+            inArray(parseJob.Status, input.statuses),
+          )
+        : and(
+            eq(parseJob.UserID, input.userId),
+            eq(parseJob.UniversityID, input.universityId),
+            eq(parseJob.AdapterKey, input.adapterKey),
+            eq(parseJob.FingerprintAlgorithm, input.fingerprintAlgorithm),
+            eq(parseJob.PdfStreamHash, input.pdfStreamHash),
+          );
 
     const [row] = await this.databaseService.db
       .select()
       .from(parseJob)
-      .where(and(...filters))
+      .where(duplicateCriteria)
       .limit(1);
 
     return row ? mapParseJob(row) : undefined;
@@ -174,41 +180,41 @@ export class PdfParserJobStoreService {
     jobId: string,
     callback: PdfParserCallbackPayload,
   ): Promise<PdfParserJobRecord> {
-    const existing = await this.findPersistedJob(jobId);
-    if (!existing) {
-      throw new NotFoundException(`PDF parser job not found: ${jobId}`);
-    }
-
-    if (existing.Status === callback.status) {
-      const existingRecord = mapParseJob(existing);
-      if (callbackMatchesExisting(existingRecord, callback)) {
-        if (
-          callback.status === 'completed' &&
-          callback.result &&
-          !existing.GroupID
-        ) {
-          const updated = await this.linkCompletedJobToDomainRecords(
-            existing,
-            callback.result,
-          );
-          return mapParseJob(updated);
-        }
-
-        return existingRecord;
+    const row = await this.databaseService.db.transaction(async (tx) => {
+      const existing = await this.findPersistedJobForUpdate(tx, jobId);
+      if (!existing) {
+        throw new NotFoundException(`PDF parser job not found: ${jobId}`);
       }
 
-      throw new ConflictException(
-        `PDF parser job already has a different ${callback.status} callback`,
-      );
-    }
+      if (existing.Status === callback.status) {
+        const existingRecord = mapParseJob(existing);
+        if (callbackMatchesExisting(existingRecord, callback)) {
+          if (
+            callback.status === 'completed' &&
+            callback.result &&
+            !existing.GroupID
+          ) {
+            return this.linkCompletedJobToDomainRecords(
+              tx,
+              existing,
+              callback.result,
+            );
+          }
 
-    if (existing.Status === 'completed' || existing.Status === 'failed') {
-      throw new ConflictException(
-        `PDF parser job is already ${existing.Status}`,
-      );
-    }
+          return existing;
+        }
 
-    const row = await this.databaseService.db.transaction(async (tx) => {
+        throw new ConflictException(
+          `PDF parser job already has a different ${callback.status} callback`,
+        );
+      }
+
+      if (existing.Status === 'completed' || existing.Status === 'failed') {
+        throw new ConflictException(
+          `PDF parser job is already ${existing.Status}`,
+        );
+      }
+
       const now = new Date();
       const moduleGroupingId =
         callback.status === 'completed' && callback.result
@@ -232,17 +238,74 @@ export class PdfParserJobStoreService {
           CompletedAt: callback.status === 'completed' ? now : null,
           FailedAt: callback.status === 'failed' ? now : null,
         })
-        .where(eq(parseJob.JobID, existing.JobID))
+        .where(
+          and(
+            eq(parseJob.JobID, existing.JobID),
+            eq(parseJob.Status, existing.Status),
+          ),
+        )
         .returning();
+
+      if (!updated) {
+        throw new ConflictException(
+          `PDF parser job changed while recording callback: ${jobId}`,
+        );
+      }
 
       return updated;
     });
 
-    if (!row) {
-      throw new NotFoundException(`PDF parser job not found: ${jobId}`);
+    return mapParseJob(row);
+  }
+
+  private async findPersistedJobForUpdate(
+    db: AppDatabase,
+    jobId: string,
+  ): Promise<ParseJob | undefined> {
+    const jobUuid = parsePublicJobId(jobId);
+    const [row] = await db
+      .select()
+      .from(parseJob)
+      .where(eq(parseJob.JobID, jobUuid))
+      .limit(1)
+      .for('update');
+
+    return row;
+  }
+
+  private async linkCompletedJobToDomainRecords(
+    db: AppDatabase,
+    existing: ParseJob,
+    result: PdfParserResult,
+  ): Promise<ParseJob> {
+    const moduleGroupingId = await this.parserResultImporter.importResult(
+      db,
+      existing,
+      result,
+    );
+    const [updated] = await db
+      .update(parseJob)
+      .set({
+        GroupID: moduleGroupingId,
+        UpdatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(parseJob.JobID, existing.JobID),
+          eq(parseJob.Status, existing.Status),
+        ),
+      )
+      .returning();
+
+    if (!updated) {
+      throw new ConflictException(
+        `PDF parser job changed while linking parser result: ${toPublicJobId(
+          existing.JobID,
+        )}`,
+      );
     }
 
-    return mapParseJob(row);
+    return updated;
   }
 
   async findJob(
@@ -273,48 +336,6 @@ export class PdfParserJobStoreService {
       .limit(1);
 
     return row ? mapParseJob(row) : undefined;
-  }
-
-  private async findPersistedJob(jobId: string): Promise<ParseJob | undefined> {
-    const jobUuid = parsePublicJobId(jobId);
-    const [row] = await this.databaseService.db
-      .select()
-      .from(parseJob)
-      .where(eq(parseJob.JobID, jobUuid))
-      .limit(1);
-
-    return row;
-  }
-
-  private async linkCompletedJobToDomainRecords(
-    existing: ParseJob,
-    result: PdfParserResult,
-  ): Promise<ParseJob> {
-    const row = await this.databaseService.db.transaction(async (tx) => {
-      const moduleGroupingId = await this.parserResultImporter.importResult(
-        tx,
-        existing,
-        result,
-      );
-      const [updated] = await tx
-        .update(parseJob)
-        .set({
-          GroupID: moduleGroupingId,
-          UpdatedAt: new Date(),
-        })
-        .where(eq(parseJob.JobID, existing.JobID))
-        .returning();
-
-      return updated;
-    });
-
-    if (!row) {
-      throw new NotFoundException(
-        `PDF parser job not found: ${toPublicJobId(existing.JobID)}`,
-      );
-    }
-
-    return row;
   }
 }
 

--- a/apps/backend/src/pdf-parser/pdf-parser.controller.spec.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.controller.spec.ts
@@ -1,0 +1,431 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import type { PdfStreamFingerprintResult } from 'shared-types';
+import { IS_PUBLIC_KEY } from '../auth/auth.guard';
+import type { SessionData } from '../auth/session.decorator';
+import { QueueProducerService } from '../jobs/queue-producer.service';
+import { WorkerCallbackAuthGuard } from '../jobs/worker-callback-auth.guard';
+import { ObjectStorageService } from '../storage/object-storage.service';
+import { PdfParserController } from './pdf-parser.controller';
+import { PdfParserFingerprintService } from './pdf-parser-fingerprint.service';
+import {
+  PdfParserJobStoreService,
+  type PdfParserJobRecord,
+} from './pdf-parser-job-store.service';
+
+describe('PdfParserController auth metadata', () => {
+  it('does not mark upload or status endpoints as public', () => {
+    expect(
+      Reflect.getMetadata(
+        IS_PUBLIC_KEY,
+        PdfParserController.prototype.uploadAndEnqueue,
+      ),
+    ).toBeUndefined();
+    expect(
+      Reflect.getMetadata(IS_PUBLIC_KEY, PdfParserController.prototype.getJob),
+    ).toBeUndefined();
+  });
+
+  it('keeps worker callbacks public for bearer-token guard access', () => {
+    expect(
+      Reflect.getMetadata(
+        IS_PUBLIC_KEY,
+        PdfParserController.prototype.receiveCallback,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('PdfParserController', () => {
+  let queueProducer: MockQueueProducer;
+  let storage: MockObjectStorage;
+  let jobStore: MockPdfParserJobStore;
+  let fingerprintService: MockPdfParserFingerprintService;
+  let controller: PdfParserController;
+
+  beforeEach(async () => {
+    queueProducer = { enqueuePdfParseJob: jest.fn().mockResolvedValue({}) };
+    storage = { putObject: jest.fn().mockResolvedValue({}) };
+    jobStore = {
+      findDuplicate: jest.fn().mockResolvedValue(undefined),
+      createQueuedJob: jest.fn().mockResolvedValue(queuedRecord),
+      retryFailedDuplicate: jest.fn().mockResolvedValue(retriedRecord),
+      markInfrastructureFailure: jest.fn().mockResolvedValue(undefined),
+      findJob: jest.fn().mockResolvedValue(queuedRecord),
+      recordCallback: jest.fn().mockResolvedValue(completedRecord),
+    };
+    fingerprintService = {
+      computeOrThrow: jest.fn().mockReturnValue(fingerprint),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [PdfParserController],
+      providers: [
+        { provide: QueueProducerService, useValue: queueProducer },
+        { provide: ObjectStorageService, useValue: storage },
+        { provide: PdfParserJobStoreService, useValue: jobStore },
+        { provide: PdfParserFingerprintService, useValue: fingerprintService },
+        {
+          provide: WorkerCallbackAuthGuard,
+          useValue: { canActivate: jest.fn() },
+        },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+
+    controller = moduleRef.get(PdfParserController);
+  });
+
+  it('returns duplicate lookup results only from the scoped store query', async () => {
+    jobStore.findDuplicate.mockResolvedValue(completedRecord);
+
+    await expect(
+      controller.lookupDuplicate(session, {
+        universityId,
+        adapterKey: 'up',
+        fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+        pdfStreamHash,
+      }),
+    ).resolves.toEqual({
+      duplicate: true,
+      jobId: completedRecord.jobId,
+      status: 'completed',
+      resultAvailable: true,
+      statusUrl: `/pdf-parser/jobs/${completedRecord.jobId}`,
+    });
+
+    expect(jobStore.findDuplicate).toHaveBeenCalledWith({
+      userId,
+      universityId,
+      adapterKey: 'up',
+      fingerprintAlgorithm: 'pdf-stream-payload-sha256-v1',
+      pdfStreamHash,
+      statuses: ['queued', 'completed'],
+    });
+  });
+
+  it('recomputes the backend hash during upload and keeps a mismatching client hash diagnostic only', async () => {
+    await controller.uploadAndEnqueue(
+      session,
+      uploadedPdf,
+      'up',
+      universityId,
+      'pdf-stream-payload-sha256-v1',
+      'f'.repeat(64),
+    );
+
+    expect(jobStore.findDuplicate).toHaveBeenCalledWith({
+      userId,
+      universityId,
+      adapterKey: 'up',
+      fingerprintAlgorithm: fingerprint.algorithmVersion,
+      pdfStreamHash: fingerprint.hash,
+      statuses: ['queued', 'completed'],
+    });
+    expect(jobStore.createQueuedJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId,
+        universityId,
+        clientPdfStreamHash: 'f'.repeat(64),
+        pdfStreamHash: fingerprint.hash,
+        streamCount: fingerprint.streamCount,
+      }),
+    );
+  });
+
+  it('returns an existing duplicate upload without storing or enqueueing another job', async () => {
+    jobStore.findDuplicate.mockResolvedValue(completedRecord);
+
+    await expect(
+      controller.uploadAndEnqueue(
+        session,
+        uploadedPdf,
+        'up',
+        universityId,
+        undefined,
+        undefined,
+      ),
+    ).resolves.toEqual({
+      jobId: completedRecord.jobId,
+      fileKey: completedRecord.fileKey,
+      adapterKey: completedRecord.adapterKey,
+      status: completedRecord.status,
+      result: completedRecord.result,
+      error: completedRecord.error,
+      createdAt: completedRecord.createdAt,
+      updatedAt: completedRecord.updatedAt,
+      statusUrl: `/pdf-parser/jobs/${completedRecord.jobId}`,
+    });
+
+    expect(storage.putObject).not.toHaveBeenCalled();
+    expect(jobStore.createQueuedJob).not.toHaveBeenCalled();
+    expect(queueProducer.enqueuePdfParseJob).not.toHaveBeenCalled();
+  });
+
+  it('creates the persisted job before enqueueing the BullMQ job', async () => {
+    const calls: string[] = [];
+    jobStore.createQueuedJob.mockImplementation(async () => {
+      calls.push('create');
+      return queuedRecord;
+    });
+    storage.putObject.mockImplementation(async () => {
+      calls.push('store');
+      return {};
+    });
+    queueProducer.enqueuePdfParseJob.mockImplementation(async () => {
+      calls.push('enqueue');
+      return {};
+    });
+
+    await controller.uploadAndEnqueue(
+      session,
+      uploadedPdf,
+      'up',
+      universityId,
+      undefined,
+      undefined,
+    );
+
+    expect(calls).toEqual(['create', 'store', 'enqueue']);
+  });
+
+  it('retries a failed duplicate upload instead of returning the failed job', async () => {
+    jobStore.createQueuedJob.mockRejectedValue(new Error('duplicate key'));
+    jobStore.findDuplicate
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(failedRecord);
+
+    await expect(
+      controller.uploadAndEnqueue(
+        session,
+        uploadedPdf,
+        'up',
+        universityId,
+        undefined,
+        undefined,
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        jobId: retriedRecord.jobId,
+        status: 'queued',
+      }),
+    );
+
+    expect(jobStore.retryFailedDuplicate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: failedRecord.jobId,
+        adapterKey: 'up',
+        pdfStreamHash,
+      }),
+    );
+    expect(storage.putObject).toHaveBeenCalledWith(
+      expect.objectContaining({ key: retriedRecord.fileKey }),
+    );
+    expect(queueProducer.enqueuePdfParseJob).toHaveBeenCalledWith({
+      jobId: retriedRecord.jobId,
+      fileKey: retriedRecord.fileKey,
+      adapterKey: 'up',
+    });
+  });
+
+  it('marks the reserved job failed when object storage fails', async () => {
+    storage.putObject.mockRejectedValue(new Error('storage down'));
+
+    await expect(
+      controller.uploadAndEnqueue(
+        session,
+        uploadedPdf,
+        'up',
+        universityId,
+        undefined,
+        undefined,
+      ),
+    ).rejects.toThrow('PDF parser upload could not be stored');
+
+    expect(jobStore.markInfrastructureFailure).toHaveBeenCalledWith(
+      queuedRecord.jobId,
+      expect.objectContaining({
+        code: 'PDF_PARSE_UPLOAD_FAILED',
+      }),
+    );
+    expect(queueProducer.enqueuePdfParseJob).not.toHaveBeenCalled();
+  });
+
+  it('marks the persisted job failed when enqueueing fails', async () => {
+    queueProducer.enqueuePdfParseJob.mockRejectedValue(new Error('redis down'));
+
+    await expect(
+      controller.uploadAndEnqueue(
+        session,
+        uploadedPdf,
+        'up',
+        universityId,
+        undefined,
+        undefined,
+      ),
+    ).rejects.toThrow('PDF parser job could not be enqueued');
+
+    expect(jobStore.markInfrastructureFailure).toHaveBeenCalledWith(
+      expect.stringMatching(/^pdf-parse-/),
+      expect.objectContaining({
+        code: 'PDF_PARSE_ENQUEUE_FAILED',
+      }),
+    );
+  });
+
+  it('persists completed worker callbacks through the store', async () => {
+    const result = { modules: [], events: [], warnings: [] };
+
+    await expect(
+      controller.receiveCallback(queuedRecord.jobId, {
+        status: 'completed',
+        result,
+      }),
+    ).resolves.toEqual({ accepted: true, jobId: queuedRecord.jobId });
+
+    expect(jobStore.recordCallback).toHaveBeenCalledWith(queuedRecord.jobId, {
+      status: 'completed',
+      result,
+    });
+  });
+
+  it('persists failed worker callbacks through the store', async () => {
+    const error = { code: 'PARSE_FAILED', message: 'bad pdf' };
+
+    await expect(
+      controller.receiveCallback(queuedRecord.jobId, {
+        status: 'failed',
+        error,
+      }),
+    ).resolves.toEqual({ accepted: true, jobId: queuedRecord.jobId });
+
+    expect(jobStore.recordCallback).toHaveBeenCalledWith(queuedRecord.jobId, {
+      status: 'failed',
+      error,
+    });
+  });
+
+  it('returns completed result JSON for the authenticated job owner', async () => {
+    jobStore.findJob.mockResolvedValue(completedRecord);
+
+    await expect(
+      controller.getJobResult(session, completedRecord.jobId),
+    ).resolves.toEqual(completedRecord.result);
+
+    expect(jobStore.findJob).toHaveBeenCalledWith(completedRecord.jobId, {
+      userId,
+    });
+  });
+
+  it('does not return another user job when the scoped store lookup misses', async () => {
+    jobStore.findJob.mockResolvedValue(undefined);
+
+    await expect(
+      controller.getJob(session, queuedRecord.jobId),
+    ).rejects.toThrow(`PDF parser job not found: ${queuedRecord.jobId}`);
+  });
+});
+
+const userId = '11111111-1111-4111-8111-111111111111';
+const universityId = '22222222-2222-4222-8222-222222222222';
+const pdfStreamHash = 'a'.repeat(64);
+type MockQueueProducer = {
+  enqueuePdfParseJob: jest.Mock;
+};
+
+type MockObjectStorage = {
+  putObject: jest.Mock;
+};
+
+type MockPdfParserJobStore = {
+  findDuplicate: jest.Mock;
+  createQueuedJob: jest.Mock;
+  retryFailedDuplicate: jest.Mock;
+  markInfrastructureFailure: jest.Mock;
+  findJob: jest.Mock;
+  recordCallback: jest.Mock;
+};
+
+type MockPdfParserFingerprintService = {
+  computeOrThrow: jest.Mock;
+};
+
+const fingerprint: Extract<PdfStreamFingerprintResult, { ok: true }> = {
+  ok: true,
+  hash: pdfStreamHash,
+  streamCount: 1,
+  algorithmVersion: 'pdf-stream-payload-sha256-v1',
+};
+
+const session: SessionData = {
+  user: {
+    id: userId,
+    name: 'Student',
+    email: 'student@example.com',
+    emailVerified: true,
+    role: 'student',
+    banned: false,
+    createdAt: '2026-07-03T00:00:00.000Z',
+    updatedAt: '2026-07-03T00:00:00.000Z',
+  },
+  session: {
+    id: 'session-1',
+    token: 'token-1',
+    userId,
+    expiresAt: '2026-07-04T00:00:00.000Z',
+    createdAt: '2026-07-03T00:00:00.000Z',
+    updatedAt: '2026-07-03T00:00:00.000Z',
+  },
+};
+
+const uploadedPdf = {
+  originalname: 'Timetable PDF.pdf',
+  mimetype: 'application/pdf',
+  buffer: Buffer.from('stream\npayload\nendstream'),
+  size: 24,
+};
+
+const queuedRecord: PdfParserJobRecord = {
+  jobId: 'pdf-parse-33333333-3333-4333-8333-333333333333',
+  fileKey:
+    'uploads/pdf-parser/pdf-parse-33333333-3333-4333-8333-333333333333/timetable-pdf.pdf',
+  adapterKey: 'up',
+  status: 'queued',
+  createdAt: '2026-07-03T00:00:00.000Z',
+  updatedAt: '2026-07-03T00:00:00.000Z',
+};
+
+const completedRecord: PdfParserJobRecord = {
+  jobId: queuedRecord.jobId,
+  fileKey: queuedRecord.fileKey,
+  adapterKey: queuedRecord.adapterKey,
+  status: 'completed',
+  result: { modules: [], events: [], warnings: [] },
+  createdAt: queuedRecord.createdAt,
+  updatedAt: queuedRecord.updatedAt,
+};
+
+const failedRecord: PdfParserJobRecord = {
+  jobId: 'pdf-parse-44444444-4444-4444-8444-444444444444',
+  fileKey:
+    'uploads/pdf-parser/pdf-parse-44444444-4444-4444-8444-444444444444/timetable-pdf.pdf',
+  adapterKey: 'up',
+  status: 'failed',
+  error: {
+    code: 'PARSER_FAILED',
+    message: 'Parser failed',
+    details: {},
+  },
+  createdAt: queuedRecord.createdAt,
+  updatedAt: queuedRecord.updatedAt,
+};
+
+const retriedRecord: PdfParserJobRecord = {
+  jobId: failedRecord.jobId,
+  fileKey:
+    'uploads/pdf-parser/pdf-parse-55555555-5555-4555-8555-555555555555/timetable-pdf.pdf',
+  adapterKey: 'up',
+  status: 'queued',
+  createdAt: failedRecord.createdAt,
+  updatedAt: failedRecord.updatedAt,
+};

--- a/apps/backend/src/pdf-parser/pdf-parser.controller.spec.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.controller.spec.ts
@@ -1,13 +1,10 @@
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import type { PdfStreamFingerprintResult } from 'shared-types';
 import { IS_PUBLIC_KEY } from '../auth/auth.guard';
 import type { SessionData } from '../auth/session.decorator';
-import { QueueProducerService } from '../jobs/queue-producer.service';
 import { WorkerCallbackAuthGuard } from '../jobs/worker-callback-auth.guard';
-import { ObjectStorageService } from '../storage/object-storage.service';
+import { PdfParseSubmission } from './pdf-parse-submission';
 import { PdfParserController } from './pdf-parser.controller';
-import { PdfParserFingerprintService } from './pdf-parser-fingerprint.service';
 import {
   PdfParserJobStoreService,
   type PdfParserJobRecord,
@@ -37,34 +34,25 @@ describe('PdfParserController auth metadata', () => {
 });
 
 describe('PdfParserController', () => {
-  let queueProducer: MockQueueProducer;
-  let storage: MockObjectStorage;
   let jobStore: MockPdfParserJobStore;
-  let fingerprintService: MockPdfParserFingerprintService;
+  let submission: MockPdfParseSubmission;
   let controller: PdfParserController;
 
   beforeEach(async () => {
-    queueProducer = { enqueuePdfParseJob: jest.fn().mockResolvedValue({}) };
-    storage = { putObject: jest.fn().mockResolvedValue({}) };
     jobStore = {
       findDuplicate: jest.fn().mockResolvedValue(undefined),
-      createQueuedJob: jest.fn().mockResolvedValue(queuedRecord),
-      retryFailedDuplicate: jest.fn().mockResolvedValue(retriedRecord),
-      markInfrastructureFailure: jest.fn().mockResolvedValue(undefined),
       findJob: jest.fn().mockResolvedValue(queuedRecord),
       recordCallback: jest.fn().mockResolvedValue(completedRecord),
     };
-    fingerprintService = {
-      computeOrThrow: jest.fn().mockReturnValue(fingerprint),
+    submission = {
+      submit: jest.fn().mockResolvedValue(uploadResponse),
     };
 
     const moduleRef = await Test.createTestingModule({
       controllers: [PdfParserController],
       providers: [
-        { provide: QueueProducerService, useValue: queueProducer },
-        { provide: ObjectStorageService, useValue: storage },
         { provide: PdfParserJobStoreService, useValue: jobStore },
-        { provide: PdfParserFingerprintService, useValue: fingerprintService },
+        { provide: PdfParseSubmission, useValue: submission },
         {
           provide: WorkerCallbackAuthGuard,
           useValue: { canActivate: jest.fn() },
@@ -104,173 +92,94 @@ describe('PdfParserController', () => {
     });
   });
 
-  it('recomputes the backend hash during upload and keeps a mismatching client hash diagnostic only', async () => {
-    await controller.uploadAndEnqueue(
-      session,
-      uploadedPdf,
-      'up',
-      universityId,
-      'pdf-stream-payload-sha256-v1',
-      'f'.repeat(64),
-    );
+  it('validates upload inputs and delegates submission', async () => {
+    await expect(
+      controller.uploadAndEnqueue(
+        session,
+        uploadedPdf,
+        ' up ',
+        universityId,
+        'pdf-stream-payload-sha256-v1',
+        'F'.repeat(64),
+      ),
+    ).resolves.toEqual(uploadResponse);
 
-    expect(jobStore.findDuplicate).toHaveBeenCalledWith({
+    expect(submission.submit).toHaveBeenCalledWith({
       userId,
       universityId,
       adapterKey: 'up',
-      fingerprintAlgorithm: fingerprint.algorithmVersion,
-      pdfStreamHash: fingerprint.hash,
-      statuses: ['queued', 'completed'],
+      clientPdfStreamHash: 'f'.repeat(64),
+      file: {
+        originalName: uploadedPdf.originalname,
+        mimetype: uploadedPdf.mimetype,
+        buffer: uploadedPdf.buffer,
+      },
     });
-    expect(jobStore.createQueuedJob).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId,
-        universityId,
-        clientPdfStreamHash: 'f'.repeat(64),
-        pdfStreamHash: fingerprint.hash,
-        streamCount: fingerprint.streamCount,
-      }),
-    );
   });
 
-  it('returns an existing duplicate upload without storing or enqueueing another job', async () => {
-    jobStore.findDuplicate.mockResolvedValue(completedRecord);
+  it('rejects unsupported upload adapters before submission', async () => {
+    await expect(
+      controller.uploadAndEnqueue(
+        session,
+        uploadedPdf,
+        'other',
+        universityId,
+        undefined,
+        undefined,
+      ),
+    ).rejects.toThrow('Only the "up" PDF adapter is supported');
 
+    expect(submission.submit).not.toHaveBeenCalled();
+  });
+
+  it('rejects uploads without PDF magic bytes', async () => {
+    await expect(
+      controller.uploadAndEnqueue(
+        session,
+        {
+          originalname: 'not-a-pdf.pdf',
+          mimetype: 'application/pdf',
+          buffer: Buffer.from('not a pdf'),
+          size: 9,
+        },
+        'up',
+        universityId,
+        undefined,
+        undefined,
+      ),
+    ).rejects.toThrow('Uploaded file must be a PDF');
+
+    expect(submission.submit).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid client fingerprint diagnostics before submission', async () => {
     await expect(
       controller.uploadAndEnqueue(
         session,
         uploadedPdf,
         'up',
         universityId,
-        undefined,
-        undefined,
+        'pdf-stream-payload-sha256-v1',
+        'not-a-hash',
       ),
-    ).resolves.toEqual({
-      jobId: completedRecord.jobId,
-      fileKey: completedRecord.fileKey,
-      adapterKey: completedRecord.adapterKey,
-      status: completedRecord.status,
-      result: completedRecord.result,
-      error: completedRecord.error,
-      createdAt: completedRecord.createdAt,
-      updatedAt: completedRecord.updatedAt,
-      statusUrl: `/pdf-parser/jobs/${completedRecord.jobId}`,
-    });
+    ).rejects.toThrow('clientPdfStreamHash must be a 64-character hex hash');
 
-    expect(storage.putObject).not.toHaveBeenCalled();
-    expect(jobStore.createQueuedJob).not.toHaveBeenCalled();
-    expect(queueProducer.enqueuePdfParseJob).not.toHaveBeenCalled();
+    expect(submission.submit).not.toHaveBeenCalled();
   });
 
-  it('creates the persisted job before enqueueing the BullMQ job', async () => {
-    const calls: string[] = [];
-    jobStore.createQueuedJob.mockImplementation(async () => {
-      calls.push('create');
-      return queuedRecord;
-    });
-    storage.putObject.mockImplementation(async () => {
-      calls.push('store');
-      return {};
-    });
-    queueProducer.enqueuePdfParseJob.mockImplementation(async () => {
-      calls.push('enqueue');
-      return {};
-    });
-
-    await controller.uploadAndEnqueue(
-      session,
-      uploadedPdf,
-      'up',
-      universityId,
-      undefined,
-      undefined,
-    );
-
-    expect(calls).toEqual(['create', 'store', 'enqueue']);
-  });
-
-  it('retries a failed duplicate upload instead of returning the failed job', async () => {
-    jobStore.createQueuedJob.mockRejectedValue(new Error('duplicate key'));
-    jobStore.findDuplicate
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(failedRecord);
-
+  it('rejects unsupported client fingerprint algorithms before submission', async () => {
     await expect(
       controller.uploadAndEnqueue(
         session,
         uploadedPdf,
         'up',
         universityId,
-        undefined,
-        undefined,
-      ),
-    ).resolves.toEqual(
-      expect.objectContaining({
-        jobId: retriedRecord.jobId,
-        status: 'queued',
-      }),
-    );
-
-    expect(jobStore.retryFailedDuplicate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        jobId: failedRecord.jobId,
-        adapterKey: 'up',
-        pdfStreamHash,
-      }),
-    );
-    expect(storage.putObject).toHaveBeenCalledWith(
-      expect.objectContaining({ key: retriedRecord.fileKey }),
-    );
-    expect(queueProducer.enqueuePdfParseJob).toHaveBeenCalledWith({
-      jobId: retriedRecord.jobId,
-      fileKey: retriedRecord.fileKey,
-      adapterKey: 'up',
-    });
-  });
-
-  it('marks the reserved job failed when object storage fails', async () => {
-    storage.putObject.mockRejectedValue(new Error('storage down'));
-
-    await expect(
-      controller.uploadAndEnqueue(
-        session,
-        uploadedPdf,
-        'up',
-        universityId,
-        undefined,
+        'unknown',
         undefined,
       ),
-    ).rejects.toThrow('PDF parser upload could not be stored');
+    ).rejects.toThrow('Unsupported fingerprint algorithm: unknown');
 
-    expect(jobStore.markInfrastructureFailure).toHaveBeenCalledWith(
-      queuedRecord.jobId,
-      expect.objectContaining({
-        code: 'PDF_PARSE_UPLOAD_FAILED',
-      }),
-    );
-    expect(queueProducer.enqueuePdfParseJob).not.toHaveBeenCalled();
-  });
-
-  it('marks the persisted job failed when enqueueing fails', async () => {
-    queueProducer.enqueuePdfParseJob.mockRejectedValue(new Error('redis down'));
-
-    await expect(
-      controller.uploadAndEnqueue(
-        session,
-        uploadedPdf,
-        'up',
-        universityId,
-        undefined,
-        undefined,
-      ),
-    ).rejects.toThrow('PDF parser job could not be enqueued');
-
-    expect(jobStore.markInfrastructureFailure).toHaveBeenCalledWith(
-      expect.stringMatching(/^pdf-parse-/),
-      expect.objectContaining({
-        code: 'PDF_PARSE_ENQUEUE_FAILED',
-      }),
-    );
+    expect(submission.submit).not.toHaveBeenCalled();
   });
 
   it('persists completed worker callbacks through the store', async () => {
@@ -329,32 +238,15 @@ describe('PdfParserController', () => {
 const userId = '11111111-1111-4111-8111-111111111111';
 const universityId = '22222222-2222-4222-8222-222222222222';
 const pdfStreamHash = 'a'.repeat(64);
-type MockQueueProducer = {
-  enqueuePdfParseJob: jest.Mock;
-};
-
-type MockObjectStorage = {
-  putObject: jest.Mock;
-};
 
 type MockPdfParserJobStore = {
   findDuplicate: jest.Mock;
-  createQueuedJob: jest.Mock;
-  retryFailedDuplicate: jest.Mock;
-  markInfrastructureFailure: jest.Mock;
   findJob: jest.Mock;
   recordCallback: jest.Mock;
 };
 
-type MockPdfParserFingerprintService = {
-  computeOrThrow: jest.Mock;
-};
-
-const fingerprint: Extract<PdfStreamFingerprintResult, { ok: true }> = {
-  ok: true,
-  hash: pdfStreamHash,
-  streamCount: 1,
-  algorithmVersion: 'pdf-stream-payload-sha256-v1',
+type MockPdfParseSubmission = {
+  submit: jest.Mock;
 };
 
 const session: SessionData = {
@@ -381,8 +273,10 @@ const session: SessionData = {
 const uploadedPdf = {
   originalname: 'Timetable PDF.pdf',
   mimetype: 'application/pdf',
-  buffer: Buffer.from('stream\npayload\nendstream'),
-  size: 24,
+  buffer: Buffer.from(
+    '%PDF-1.7\n1 0 obj\n<< /Length 7 >>\nstream\npayload\nendstream\nendobj\n',
+  ),
+  size: 67,
 };
 
 const queuedRecord: PdfParserJobRecord = {
@@ -405,27 +299,15 @@ const completedRecord: PdfParserJobRecord = {
   updatedAt: queuedRecord.updatedAt,
 };
 
-const failedRecord: PdfParserJobRecord = {
-  jobId: 'pdf-parse-44444444-4444-4444-8444-444444444444',
-  fileKey:
-    'uploads/pdf-parser/pdf-parse-44444444-4444-4444-8444-444444444444/timetable-pdf.pdf',
-  adapterKey: 'up',
-  status: 'failed',
-  error: {
-    code: 'PARSER_FAILED',
-    message: 'Parser failed',
-    details: {},
-  },
+const uploadResponse = {
+  jobId: queuedRecord.jobId,
+  fileKey: queuedRecord.fileKey,
+  adapterKey: queuedRecord.adapterKey,
+  status: queuedRecord.status,
+  result: queuedRecord.result,
+  error: queuedRecord.error,
+  moduleGroupingId: queuedRecord.moduleGroupingId,
   createdAt: queuedRecord.createdAt,
   updatedAt: queuedRecord.updatedAt,
-};
-
-const retriedRecord: PdfParserJobRecord = {
-  jobId: failedRecord.jobId,
-  fileKey:
-    'uploads/pdf-parser/pdf-parse-55555555-5555-4555-8555-555555555555/timetable-pdf.pdf',
-  adapterKey: 'up',
-  status: 'queued',
-  createdAt: failedRecord.createdAt,
-  updatedAt: failedRecord.updatedAt,
+  statusUrl: `/pdf-parser/jobs/${queuedRecord.jobId}`,
 };

--- a/apps/backend/src/pdf-parser/pdf-parser.controller.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.controller.ts
@@ -215,7 +215,7 @@ export class PdfParserController {
     @Param('jobId') jobId: string,
   ): Promise<PdfParserResult> {
     const job = await this.jobStore.findJob(jobId, { userId: session.user.id });
-    if (!job || job.status !== 'completed' || !job.result) {
+    if (job?.status !== 'completed' || !job.result) {
       throw new NotFoundException(`PDF parser result not found: ${jobId}`);
     }
 

--- a/apps/backend/src/pdf-parser/pdf-parser.controller.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.controller.ts
@@ -1,0 +1,230 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import type {
+  ParseAnnotation,
+  ParsedEventCandidate,
+  ParsedModuleCandidate,
+  PdfParserResult,
+} from 'shared-types';
+import { Public } from '../auth/auth.guard';
+import { WorkerCallbackAuthGuard } from '../jobs/worker-callback-auth.guard';
+import { PdfParserCallbackDto } from './dto/pdf-parser-callback.dto';
+
+@Public()
+@ApiTags('PDF Parser')
+@ApiBearerAuth('bearer')
+@UseGuards(WorkerCallbackAuthGuard)
+@Controller('pdf-parser')
+export class PdfParserController {
+  @Post('jobs/:jobId/callback')
+  @HttpCode(HttpStatus.ACCEPTED)
+  receiveCallback(
+    @Param('jobId') jobId: string,
+    @Body() body: PdfParserCallbackDto,
+  ) {
+    validatePdfParserCallback(body);
+
+    // TODO: Persist parser job status and surface import candidates to the UI.
+    return { accepted: true, jobId };
+  }
+}
+
+function validatePdfParserCallback(body: PdfParserCallbackDto): void {
+  if (body.status === 'completed') {
+    if (!body.result) {
+      throw new BadRequestException(
+        'Completed parser callbacks require result',
+      );
+    }
+    validateParserResultShape(body.result);
+    return;
+  }
+
+  if (!body.error?.code || !body.error.message) {
+    throw new BadRequestException('Failed parser callbacks require error');
+  }
+}
+
+function validateParserResultShape(result: PdfParserResult): void {
+  assertExactKeys(result, ['events', 'modules', 'warnings'], 'parser result');
+
+  if (!Array.isArray(result.modules)) {
+    throw new BadRequestException('Parser result modules must be an array');
+  }
+
+  if (!Array.isArray(result.events)) {
+    throw new BadRequestException('Parser result events must be an array');
+  }
+
+  validateAnnotations(result.warnings, 'parser result warnings');
+
+  for (const moduleCandidate of result.modules) {
+    validateModuleCandidate(moduleCandidate);
+  }
+
+  for (const eventCandidate of result.events) {
+    validateEventCandidate(eventCandidate);
+  }
+}
+
+function validateModuleCandidate(candidate: ParsedModuleCandidate): void {
+  assertExactKeys(
+    candidate,
+    ['code', 'metadata', 'name', 'warnings'],
+    'module candidate',
+  );
+  if (typeof candidate.code !== 'string') {
+    throw new BadRequestException('Module candidate code must be a string');
+  }
+  if (candidate.name !== null && typeof candidate.name !== 'string') {
+    throw new BadRequestException(
+      'Module candidate name must be a string or null',
+    );
+  }
+  if (!isRecord(candidate.metadata)) {
+    throw new BadRequestException(
+      'Module candidate metadata must be an object',
+    );
+  }
+  validateAnnotations(candidate.warnings, 'module candidate warnings');
+}
+
+function validateEventCandidate(candidate: ParsedEventCandidate): void {
+  assertExactKeys(
+    candidate,
+    [
+      'date',
+      'day',
+      'endTime',
+      'isRecurring',
+      'metadata',
+      'moduleCode',
+      'sectionLabel',
+      'startTime',
+      'title',
+      'type',
+      'venues',
+      'warnings',
+    ],
+    'event candidate',
+  );
+
+  const stringFields = [
+    'moduleCode',
+    'type',
+    'sectionLabel',
+    'title',
+    'startTime',
+    'endTime',
+  ] as const;
+
+  for (const key of stringFields) {
+    if (typeof candidate[key] !== 'string') {
+      throw new BadRequestException(`Event candidate ${key} must be a string`);
+    }
+  }
+
+  if (candidate.day !== null && typeof candidate.day !== 'string') {
+    throw new BadRequestException(
+      'Event candidate day must be a string or null',
+    );
+  }
+
+  if (candidate.date !== null && typeof candidate.date !== 'string') {
+    throw new BadRequestException(
+      'Event candidate date must be a string or null',
+    );
+  }
+
+  if (!Array.isArray(candidate.venues)) {
+    throw new BadRequestException('Event candidate venues must be an array');
+  }
+
+  for (const venue of candidate.venues) {
+    if (typeof venue !== 'string') {
+      throw new BadRequestException('Event candidate venues must be strings');
+    }
+  }
+
+  if (typeof candidate.isRecurring !== 'boolean') {
+    throw new BadRequestException(
+      'Event candidate isRecurring must be a boolean',
+    );
+  }
+
+  if (!isRecord(candidate.metadata)) {
+    throw new BadRequestException('Event candidate metadata must be an object');
+  }
+
+  validateAnnotations(candidate.warnings, 'event candidate warnings');
+}
+
+function validateAnnotations(
+  annotations: ParseAnnotation[] | undefined,
+  label: string,
+): void {
+  if (!Array.isArray(annotations)) {
+    throw new BadRequestException(`${label} must be an array`);
+  }
+  for (const annotation of annotations) {
+    assertExactKeys(annotation, ['code', 'details', 'message'], label);
+
+    if (typeof annotation.code !== 'string') {
+      throw new BadRequestException(`${label} code must be a string`);
+    }
+
+    if (typeof annotation.message !== 'string') {
+      throw new BadRequestException(`${label} message must be a string`);
+    }
+
+    if (!isRecord(annotation.details)) {
+      throw new BadRequestException(`${label} details must be an object`);
+    }
+  }
+}
+
+function assertExactKeys(
+  value: unknown,
+  expectedKeys: string[],
+  label: string,
+): void {
+  if (!isRecord(value)) {
+    throw new BadRequestException(`${label} must be an object`);
+  }
+
+  const actualKeys = Object.keys(value).sort();
+  const expected = expectedKeys.slice().sort();
+
+  if (!hasSameKeys(actualKeys, expected)) {
+    throw new BadRequestException(
+      `${label} must contain exactly: ${expected.join(', ')}`,
+    );
+  }
+}
+
+function hasSameKeys(actualKeys: string[], expectedKeys: string[]): boolean {
+  if (actualKeys.length !== expectedKeys.length) {
+    return false;
+  }
+
+  for (let index = 0; index < actualKeys.length; index += 1) {
+    if (actualKeys[index] !== expectedKeys[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/backend/src/pdf-parser/pdf-parser.controller.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.controller.ts
@@ -5,7 +5,6 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  InternalServerErrorException,
   NotFoundException,
   Param,
   Post,
@@ -23,7 +22,6 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { randomUUID } from 'node:crypto';
 import type { PdfParserCallbackPayload, PdfParserResult } from 'shared-types';
 import {
   PDF_STREAM_FINGERPRINT_ALGORITHM_VERSION,
@@ -31,29 +29,22 @@ import {
 } from 'shared-types';
 import { Public } from '../auth/auth.guard';
 import { CurrentSession, type SessionData } from '../auth/session.decorator';
-import { QueueProducerService } from '../jobs/queue-producer.service';
 import { WorkerCallbackAuthGuard } from '../jobs/worker-callback-auth.guard';
-import { ObjectStorageService } from '../storage/object-storage.service';
 import { PdfParserCallbackDto } from './dto/pdf-parser-callback.dto';
 import {
   PdfParserJobResponseDto,
   PdfParserLookupResponseDto,
   PdfParserUploadResponseDto,
 } from './dto/pdf-parser-job-response.dto';
-import { PdfParserFingerprintService } from './pdf-parser-fingerprint.service';
-import {
-  PdfParserJobStoreService,
-  type PdfParserJobRecord,
-} from './pdf-parser-job-store.service';
+import { PdfParseSubmission } from './pdf-parse-submission';
+import { PdfParserJobStoreService } from './pdf-parser-job-store.service';
 
 @ApiTags('PDF Parser')
 @Controller('pdf-parser')
 export class PdfParserController {
   constructor(
-    private readonly queueProducer: QueueProducerService,
-    private readonly storage: ObjectStorageService,
     private readonly jobStore: PdfParserJobStoreService,
-    private readonly fingerprintService: PdfParserFingerprintService,
+    private readonly submission: PdfParseSubmission,
   ) {}
 
   @Post('jobs/lookup')
@@ -179,132 +170,18 @@ export class PdfParserController {
       'clientPdfStreamHash',
     );
     validateOptionalClientAlgorithm(fingerprintAlgorithmInput);
-    const fingerprint = this.fingerprintService.computeOrThrow(file.buffer);
 
-    const duplicate = await this.jobStore.findDuplicate({
+    return this.submission.submit({
       userId: session.user.id,
       universityId,
-      adapterKey,
-      fingerprintAlgorithm: fingerprint.algorithmVersion,
-      pdfStreamHash: fingerprint.hash,
-      statuses: ['queued', 'completed'],
-    });
-
-    if (duplicate) {
-      return toUploadResponse(duplicate);
-    }
-
-    const jobId = `pdf-parse-${randomUUID()}`;
-    const fileKey = buildFileKey(jobId, file.originalname);
-    const preparedJob = await this.prepareUploadJob({
-      jobId,
-      userId: session.user.id,
-      universityId,
-      fileKey,
       adapterKey,
       clientPdfStreamHash,
-      pdfStreamHash: fingerprint.hash,
-      fingerprintAlgorithm: fingerprint.algorithmVersion,
-      streamCount: fingerprint.streamCount,
+      file: {
+        originalName: file.originalname,
+        mimetype: file.mimetype,
+        buffer: file.buffer,
+      },
     });
-
-    if (preparedJob.kind === 'existing') {
-      return toUploadResponse(preparedJob.record);
-    }
-
-    const record = preparedJob.record;
-    const storageFileKey = record.fileKey ?? fileKey;
-
-    try {
-      await this.storage.putObject({
-        key: storageFileKey,
-        body: file.buffer,
-        contentType: file.mimetype || 'application/pdf',
-      });
-    } catch (error) {
-      await this.jobStore.markInfrastructureFailure(record.jobId, {
-        code: 'PDF_PARSE_UPLOAD_FAILED',
-        message: 'PDF parser upload could not be stored',
-        details: {
-          cause: error instanceof Error ? error.message : String(error),
-        },
-      });
-      throw new InternalServerErrorException(
-        'PDF parser upload could not be stored',
-      );
-    }
-
-    try {
-      await this.queueProducer.enqueuePdfParseJob({
-        jobId: record.jobId,
-        fileKey: storageFileKey,
-        adapterKey,
-      });
-    } catch (error) {
-      await this.jobStore.markInfrastructureFailure(record.jobId, {
-        code: 'PDF_PARSE_ENQUEUE_FAILED',
-        message: 'PDF parser job could not be enqueued',
-        details: {
-          cause: error instanceof Error ? error.message : String(error),
-        },
-      });
-      throw new InternalServerErrorException(
-        'PDF parser job could not be enqueued',
-      );
-    }
-
-    return {
-      jobId: record.jobId,
-      fileKey: record.fileKey,
-      adapterKey: record.adapterKey,
-      status: record.status,
-      result: record.result,
-      error: record.error,
-      moduleGroupingId: record.moduleGroupingId,
-      createdAt: record.createdAt,
-      updatedAt: record.updatedAt,
-      statusUrl: `/pdf-parser/jobs/${record.jobId}`,
-    };
-  }
-
-  private async prepareUploadJob(
-    input: PrepareUploadJobInput,
-  ): Promise<PreparedUploadJob> {
-    try {
-      return {
-        kind: 'pending',
-        record: await this.jobStore.createQueuedJob(input),
-      };
-    } catch (error) {
-      const duplicate = await this.jobStore.findDuplicate({
-        userId: input.userId,
-        universityId: input.universityId,
-        adapterKey: input.adapterKey,
-        fingerprintAlgorithm: input.fingerprintAlgorithm,
-        pdfStreamHash: input.pdfStreamHash,
-      });
-
-      if (!duplicate) {
-        throw error;
-      }
-
-      if (duplicate.status !== 'failed') {
-        return { kind: 'existing', record: duplicate };
-      }
-
-      return {
-        kind: 'pending',
-        record: await this.jobStore.retryFailedDuplicate({
-          jobId: duplicate.jobId,
-          fileKey: input.fileKey,
-          adapterKey: input.adapterKey,
-          clientPdfStreamHash: input.clientPdfStreamHash,
-          pdfStreamHash: input.pdfStreamHash,
-          fingerprintAlgorithm: input.fingerprintAlgorithm,
-          streamCount: input.streamCount,
-        }),
-      };
-    }
   }
 
   @Get('jobs/:jobId')
@@ -376,22 +253,6 @@ interface PdfParserLookupRequestBody {
   pdfStreamHash?: unknown;
 }
 
-interface PrepareUploadJobInput {
-  jobId: string;
-  userId: string;
-  universityId: string;
-  fileKey: string;
-  adapterKey: string;
-  clientPdfStreamHash?: string;
-  pdfStreamHash: string;
-  fingerprintAlgorithm: string;
-  streamCount: number;
-}
-
-type PreparedUploadJob =
-  | { kind: 'pending'; record: PdfParserJobRecord }
-  | { kind: 'existing'; record: PdfParserJobRecord };
-
 function validateUploadedPdf(
   file: UploadedPdfFile | undefined,
 ): asserts file is UploadedPdfFile {
@@ -403,6 +264,10 @@ function validateUploadedPdf(
     throw new BadRequestException('PDF file is empty');
   }
 
+  if (!hasPdfMagicBytes(file.buffer)) {
+    throw new BadRequestException('Uploaded file must be a PDF');
+  }
+
   const hasPdfMimeType = file.mimetype === 'application/pdf';
   const hasPdfFileName = /\.pdf$/i.test(file.originalname);
   if (!hasPdfMimeType && !hasPdfFileName) {
@@ -410,21 +275,15 @@ function validateUploadedPdf(
   }
 }
 
-function toUploadResponse(
-  record: PdfParserJobRecord,
-): PdfParserUploadResponseDto {
-  return {
-    jobId: record.jobId,
-    fileKey: record.fileKey,
-    adapterKey: record.adapterKey,
-    status: record.status,
-    result: record.result,
-    error: record.error,
-    moduleGroupingId: record.moduleGroupingId,
-    createdAt: record.createdAt,
-    updatedAt: record.updatedAt,
-    statusUrl: `/pdf-parser/jobs/${record.jobId}`,
-  };
+function hasPdfMagicBytes(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 5 &&
+    buffer[0] === 37 &&
+    buffer[1] === 80 &&
+    buffer[2] === 68 &&
+    buffer[3] === 70 &&
+    buffer[4] === 45
+  );
 }
 
 function normalizeAdapterKey(adapterKeyInput: string | undefined): string {
@@ -508,16 +367,6 @@ function normalizeOptionalHexHash(
   }
 
   return normalizeRequiredHexHash(value, fieldName);
-}
-
-function buildFileKey(jobId: string, originalName: string): string {
-  const safeName = originalName
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9.-]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-
-  return `uploads/pdf-parser/${jobId}/${safeName || 'input.pdf'}`;
 }
 
 function validatePdfParserCallback(

--- a/apps/backend/src/pdf-parser/pdf-parser.controller.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.controller.ts
@@ -2,229 +2,205 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
+  NotFoundException,
   Param,
   Post,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
-import type {
-  ParseAnnotation,
-  ParsedEventCandidate,
-  ParsedModuleCandidate,
-  PdfParserResult,
-} from 'shared-types';
+import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiAcceptedResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { randomUUID } from 'node:crypto';
+import type { PdfParserCallbackPayload } from 'shared-types';
+import { PdfParserCallbackPayloadSchema } from 'shared-types';
 import { Public } from '../auth/auth.guard';
+import { QueueProducerService } from '../jobs/queue-producer.service';
 import { WorkerCallbackAuthGuard } from '../jobs/worker-callback-auth.guard';
+import { ObjectStorageService } from '../storage/object-storage.service';
 import { PdfParserCallbackDto } from './dto/pdf-parser-callback.dto';
+import {
+  PdfParserJobResponseDto,
+  PdfParserUploadResponseDto,
+} from './dto/pdf-parser-job-response.dto';
+import { PdfParserJobStoreService } from './pdf-parser-job-store.service';
 
-@Public()
 @ApiTags('PDF Parser')
-@ApiBearerAuth('bearer')
-@UseGuards(WorkerCallbackAuthGuard)
 @Controller('pdf-parser')
 export class PdfParserController {
+  constructor(
+    private readonly queueProducer: QueueProducerService,
+    private readonly storage: ObjectStorageService,
+    private readonly jobStore: PdfParserJobStoreService,
+  ) {}
+
+  @Public()
+  @Post('jobs/upload')
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: 25 * 1024 * 1024 },
+    }),
+  )
+  @ApiOperation({
+    summary: 'Upload a timetable PDF and enqueue it for parsing',
+    description:
+      'Temporary backend-only test endpoint. Results are stored in memory until database persistence is implemented.',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'Timetable PDF to parse.',
+        },
+        adapterKey: {
+          type: 'string',
+          default: 'up',
+          description: 'Parser adapter key. Only "up" is currently supported.',
+        },
+      },
+    },
+  })
+  @ApiAcceptedResponse({ type: PdfParserUploadResponseDto })
+  @HttpCode(HttpStatus.ACCEPTED)
+  async uploadAndEnqueue(
+    @UploadedFile() file: UploadedPdfFile | undefined,
+    @Body('adapterKey') adapterKeyInput?: string,
+  ): Promise<PdfParserUploadResponseDto> {
+    validateUploadedPdf(file);
+
+    const adapterKey = normalizeAdapterKey(adapterKeyInput);
+    const jobId = `pdf-parse-${randomUUID()}`;
+    const fileKey = buildFileKey(jobId, file.originalname);
+
+    await this.storage.putObject({
+      key: fileKey,
+      body: file.buffer,
+      contentType: file.mimetype || 'application/pdf',
+    });
+
+    const record = this.jobStore.createQueuedJob({
+      jobId,
+      fileKey,
+      adapterKey,
+    });
+
+    await this.queueProducer.enqueuePdfParseJob({
+      jobId,
+      fileKey,
+      adapterKey,
+    });
+
+    return {
+      ...record,
+      statusUrl: `/pdf-parser/jobs/${jobId}`,
+    };
+  }
+
+  @Public()
+  @Get('jobs/:jobId')
+  @ApiOperation({
+    summary: 'Get temporary PDF parser job status and result',
+    description:
+      'Temporary in-memory status endpoint for local Swagger testing. Data is lost when the backend restarts.',
+  })
+  @ApiOkResponse({ type: PdfParserJobResponseDto })
+  getJob(@Param('jobId') jobId: string): PdfParserJobResponseDto {
+    const job = this.jobStore.findJob(jobId);
+    if (!job) {
+      throw new NotFoundException(`PDF parser job not found: ${jobId}`);
+    }
+
+    return job;
+  }
+
+  @Public()
   @Post('jobs/:jobId/callback')
+  @ApiBearerAuth('bearer')
+  @UseGuards(WorkerCallbackAuthGuard)
+  @ApiOperation({ summary: 'Receive final PDF parser worker callback' })
   @HttpCode(HttpStatus.ACCEPTED)
   receiveCallback(
     @Param('jobId') jobId: string,
     @Body() body: PdfParserCallbackDto,
   ) {
-    validatePdfParserCallback(body);
+    const callback = validatePdfParserCallback(body);
+    this.jobStore.recordCallback(jobId, callback);
 
     // TODO: Persist parser job status and surface import candidates to the UI.
     return { accepted: true, jobId };
   }
 }
 
-function validatePdfParserCallback(body: PdfParserCallbackDto): void {
-  if (body.status === 'completed') {
-    if (!body.result) {
-      throw new BadRequestException(
-        'Completed parser callbacks require result',
-      );
-    }
-    validateParserResultShape(body.result);
-    return;
+interface UploadedPdfFile {
+  originalname: string;
+  mimetype: string;
+  buffer: Buffer;
+  size: number;
+}
+
+function validateUploadedPdf(
+  file: UploadedPdfFile | undefined,
+): asserts file is UploadedPdfFile {
+  if (!file) {
+    throw new BadRequestException('PDF file is required');
   }
 
-  if (!body.error?.code || !body.error.message) {
-    throw new BadRequestException('Failed parser callbacks require error');
+  if (!file.buffer || file.size <= 0) {
+    throw new BadRequestException('PDF file is empty');
+  }
+
+  const hasPdfMimeType = file.mimetype === 'application/pdf';
+  const hasPdfFileName = /\.pdf$/i.test(file.originalname);
+  if (!hasPdfMimeType && !hasPdfFileName) {
+    throw new BadRequestException('Uploaded file must be a PDF');
   }
 }
 
-function validateParserResultShape(result: PdfParserResult): void {
-  assertExactKeys(result, ['events', 'modules', 'warnings'], 'parser result');
-
-  if (!Array.isArray(result.modules)) {
-    throw new BadRequestException('Parser result modules must be an array');
+function normalizeAdapterKey(adapterKeyInput: string | undefined): string {
+  const adapterKey = adapterKeyInput?.trim() || 'up';
+  if (adapterKey !== 'up') {
+    throw new BadRequestException('Only the "up" PDF adapter is supported');
   }
 
-  if (!Array.isArray(result.events)) {
-    throw new BadRequestException('Parser result events must be an array');
-  }
-
-  validateAnnotations(result.warnings, 'parser result warnings');
-
-  for (const moduleCandidate of result.modules) {
-    validateModuleCandidate(moduleCandidate);
-  }
-
-  for (const eventCandidate of result.events) {
-    validateEventCandidate(eventCandidate);
-  }
+  return adapterKey;
 }
 
-function validateModuleCandidate(candidate: ParsedModuleCandidate): void {
-  assertExactKeys(
-    candidate,
-    ['code', 'metadata', 'name', 'warnings'],
-    'module candidate',
-  );
-  if (typeof candidate.code !== 'string') {
-    throw new BadRequestException('Module candidate code must be a string');
-  }
-  if (candidate.name !== null && typeof candidate.name !== 'string') {
-    throw new BadRequestException(
-      'Module candidate name must be a string or null',
-    );
-  }
-  if (!isRecord(candidate.metadata)) {
-    throw new BadRequestException(
-      'Module candidate metadata must be an object',
-    );
-  }
-  validateAnnotations(candidate.warnings, 'module candidate warnings');
+function buildFileKey(jobId: string, originalName: string): string {
+  const safeName = originalName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return `uploads/pdf-parser/${jobId}/${safeName || 'input.pdf'}`;
 }
 
-function validateEventCandidate(candidate: ParsedEventCandidate): void {
-  assertExactKeys(
-    candidate,
-    [
-      'date',
-      'day',
-      'endTime',
-      'isRecurring',
-      'metadata',
-      'moduleCode',
-      'sectionLabel',
-      'startTime',
-      'title',
-      'type',
-      'venues',
-      'warnings',
-    ],
-    'event candidate',
-  );
-
-  const stringFields = [
-    'moduleCode',
-    'type',
-    'sectionLabel',
-    'title',
-    'startTime',
-    'endTime',
-  ] as const;
-
-  for (const key of stringFields) {
-    if (typeof candidate[key] !== 'string') {
-      throw new BadRequestException(`Event candidate ${key} must be a string`);
-    }
+function validatePdfParserCallback(
+  body: PdfParserCallbackDto,
+): PdfParserCallbackPayload {
+  const result = PdfParserCallbackPayloadSchema.safeParse(body);
+  if (result.success) {
+    return result.data;
   }
 
-  if (candidate.day !== null && typeof candidate.day !== 'string') {
-    throw new BadRequestException(
-      'Event candidate day must be a string or null',
-    );
-  }
-
-  if (candidate.date !== null && typeof candidate.date !== 'string') {
-    throw new BadRequestException(
-      'Event candidate date must be a string or null',
-    );
-  }
-
-  if (!Array.isArray(candidate.venues)) {
-    throw new BadRequestException('Event candidate venues must be an array');
-  }
-
-  for (const venue of candidate.venues) {
-    if (typeof venue !== 'string') {
-      throw new BadRequestException('Event candidate venues must be strings');
-    }
-  }
-
-  if (typeof candidate.isRecurring !== 'boolean') {
-    throw new BadRequestException(
-      'Event candidate isRecurring must be a boolean',
-    );
-  }
-
-  if (!isRecord(candidate.metadata)) {
-    throw new BadRequestException('Event candidate metadata must be an object');
-  }
-
-  validateAnnotations(candidate.warnings, 'event candidate warnings');
-}
-
-function validateAnnotations(
-  annotations: ParseAnnotation[] | undefined,
-  label: string,
-): void {
-  if (!Array.isArray(annotations)) {
-    throw new BadRequestException(`${label} must be an array`);
-  }
-  for (const annotation of annotations) {
-    assertExactKeys(annotation, ['code', 'details', 'message'], label);
-
-    if (typeof annotation.code !== 'string') {
-      throw new BadRequestException(`${label} code must be a string`);
-    }
-
-    if (typeof annotation.message !== 'string') {
-      throw new BadRequestException(`${label} message must be a string`);
-    }
-
-    if (!isRecord(annotation.details)) {
-      throw new BadRequestException(`${label} details must be an object`);
-    }
-  }
-}
-
-function assertExactKeys(
-  value: unknown,
-  expectedKeys: string[],
-  label: string,
-): void {
-  if (!isRecord(value)) {
-    throw new BadRequestException(`${label} must be an object`);
-  }
-
-  const actualKeys = Object.keys(value).sort();
-  const expected = expectedKeys.slice().sort();
-
-  if (!hasSameKeys(actualKeys, expected)) {
-    throw new BadRequestException(
-      `${label} must contain exactly: ${expected.join(', ')}`,
-    );
-  }
-}
-
-function hasSameKeys(actualKeys: string[], expectedKeys: string[]): boolean {
-  if (actualKeys.length !== expectedKeys.length) {
-    return false;
-  }
-
-  for (let index = 0; index < actualKeys.length; index += 1) {
-    if (actualKeys[index] !== expectedKeys[index]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  throw new BadRequestException({
+    message: 'PDF parser callback did not match the shared parser contract',
+    issues: result.error.issues,
+  });
 }

--- a/apps/backend/src/pdf-parser/pdf-parser.controller.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.controller.ts
@@ -201,8 +201,8 @@ function assertExactKeys(
     throw new BadRequestException(`${label} must be an object`);
   }
 
-  const actualKeys = Object.keys(value).sort((a, b) => a.localeCompare(b));
-  const expected = expectedKeys.slice().sort((a, b) => a.localeCompare(b));
+  const actualKeys = Object.keys(value).sort();
+  const expected = expectedKeys.slice().sort();
 
   if (!hasSameKeys(actualKeys, expected)) {
     throw new BadRequestException(

--- a/apps/backend/src/pdf-parser/pdf-parser.controller.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  InternalServerErrorException,
   NotFoundException,
   Param,
   Post,
@@ -23,18 +24,27 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { randomUUID } from 'node:crypto';
-import type { PdfParserCallbackPayload } from 'shared-types';
-import { PdfParserCallbackPayloadSchema } from 'shared-types';
+import type { PdfParserCallbackPayload, PdfParserResult } from 'shared-types';
+import {
+  PDF_STREAM_FINGERPRINT_ALGORITHM_VERSION,
+  PdfParserCallbackPayloadSchema,
+} from 'shared-types';
 import { Public } from '../auth/auth.guard';
+import { CurrentSession, type SessionData } from '../auth/session.decorator';
 import { QueueProducerService } from '../jobs/queue-producer.service';
 import { WorkerCallbackAuthGuard } from '../jobs/worker-callback-auth.guard';
 import { ObjectStorageService } from '../storage/object-storage.service';
 import { PdfParserCallbackDto } from './dto/pdf-parser-callback.dto';
 import {
   PdfParserJobResponseDto,
+  PdfParserLookupResponseDto,
   PdfParserUploadResponseDto,
 } from './dto/pdf-parser-job-response.dto';
-import { PdfParserJobStoreService } from './pdf-parser-job-store.service';
+import { PdfParserFingerprintService } from './pdf-parser-fingerprint.service';
+import {
+  PdfParserJobStoreService,
+  type PdfParserJobRecord,
+} from './pdf-parser-job-store.service';
 
 @ApiTags('PDF Parser')
 @Controller('pdf-parser')
@@ -43,9 +53,65 @@ export class PdfParserController {
     private readonly queueProducer: QueueProducerService,
     private readonly storage: ObjectStorageService,
     private readonly jobStore: PdfParserJobStoreService,
+    private readonly fingerprintService: PdfParserFingerprintService,
   ) {}
 
-  @Public()
+  @Post('jobs/lookup')
+  @ApiOperation({
+    summary: 'Look up an existing PDF parser job by PDF stream fingerprint',
+    description:
+      'Checks for an existing parser job scoped to the authenticated user, selected university, parser adapter, and backend-supported fingerprint algorithm.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: [
+        'universityId',
+        'adapterKey',
+        'fingerprintAlgorithm',
+        'pdfStreamHash',
+      ],
+      properties: {
+        universityId: { type: 'string', format: 'uuid' },
+        adapterKey: { type: 'string', default: 'up' },
+        fingerprintAlgorithm: {
+          type: 'string',
+          default: PDF_STREAM_FINGERPRINT_ALGORITHM_VERSION,
+        },
+        pdfStreamHash: { type: 'string', minLength: 64, maxLength: 64 },
+        streamCount: { type: 'number' },
+      },
+    },
+  })
+  @ApiOkResponse({ type: PdfParserLookupResponseDto })
+  async lookupDuplicate(
+    @CurrentSession() session: SessionData,
+    @Body() body: PdfParserLookupRequestBody,
+  ): Promise<PdfParserLookupResponseDto> {
+    const request = validateLookupRequest(body);
+    const duplicate = await this.jobStore.findDuplicate({
+      userId: session.user.id,
+      universityId: request.universityId,
+      adapterKey: request.adapterKey,
+      fingerprintAlgorithm: request.fingerprintAlgorithm,
+      pdfStreamHash: request.pdfStreamHash,
+      statuses: ['queued', 'completed'],
+    });
+
+    if (!duplicate) {
+      return { duplicate: false };
+    }
+
+    return {
+      duplicate: true,
+      jobId: duplicate.jobId,
+      status: duplicate.status,
+      moduleGroupingId: duplicate.moduleGroupingId,
+      resultAvailable: duplicate.status === 'completed' && !!duplicate.result,
+      statusUrl: `/pdf-parser/jobs/${duplicate.jobId}`,
+    };
+  }
+
   @Post('jobs/upload')
   @UseInterceptors(
     FileInterceptor('file', {
@@ -55,13 +121,13 @@ export class PdfParserController {
   @ApiOperation({
     summary: 'Upload a timetable PDF and enqueue it for parsing',
     description:
-      'Temporary backend-only test endpoint. Results are stored in memory until database persistence is implemented.',
+      'Uploads a PDF, recomputes the backend stream-payload fingerprint, persists the parse job, and enqueues it for worker parsing.',
   })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: {
       type: 'object',
-      required: ['file'],
+      required: ['file', 'universityId'],
       properties: {
         file: {
           type: 'string',
@@ -73,60 +139,210 @@ export class PdfParserController {
           default: 'up',
           description: 'Parser adapter key. Only "up" is currently supported.',
         },
+        universityId: {
+          type: 'string',
+          format: 'uuid',
+          description: 'Selected university for duplicate scoping.',
+        },
+        fingerprintAlgorithm: {
+          type: 'string',
+          default: PDF_STREAM_FINGERPRINT_ALGORITHM_VERSION,
+          description: 'Client-computed fingerprint algorithm, if available.',
+        },
+        clientPdfStreamHash: {
+          type: 'string',
+          description: 'Client-computed PDF stream hash for diagnostics only.',
+        },
+        streamCount: {
+          type: 'number',
+          description: 'Client-observed PDF stream count for diagnostics only.',
+        },
       },
     },
   })
   @ApiAcceptedResponse({ type: PdfParserUploadResponseDto })
   @HttpCode(HttpStatus.ACCEPTED)
   async uploadAndEnqueue(
+    @CurrentSession() session: SessionData,
     @UploadedFile() file: UploadedPdfFile | undefined,
     @Body('adapterKey') adapterKeyInput?: string,
+    @Body('universityId') universityIdInput?: string,
+    @Body('fingerprintAlgorithm') fingerprintAlgorithmInput?: string,
+    @Body('clientPdfStreamHash') clientPdfStreamHashInput?: string,
   ): Promise<PdfParserUploadResponseDto> {
     validateUploadedPdf(file);
 
     const adapterKey = normalizeAdapterKey(adapterKeyInput);
+    const universityId = validateUuid(universityIdInput, 'universityId');
+    const clientPdfStreamHash = normalizeOptionalHexHash(
+      clientPdfStreamHashInput,
+      'clientPdfStreamHash',
+    );
+    validateOptionalClientAlgorithm(fingerprintAlgorithmInput);
+    const fingerprint = this.fingerprintService.computeOrThrow(file.buffer);
+
+    const duplicate = await this.jobStore.findDuplicate({
+      userId: session.user.id,
+      universityId,
+      adapterKey,
+      fingerprintAlgorithm: fingerprint.algorithmVersion,
+      pdfStreamHash: fingerprint.hash,
+      statuses: ['queued', 'completed'],
+    });
+
+    if (duplicate) {
+      return toUploadResponse(duplicate);
+    }
+
     const jobId = `pdf-parse-${randomUUID()}`;
     const fileKey = buildFileKey(jobId, file.originalname);
-
-    await this.storage.putObject({
-      key: fileKey,
-      body: file.buffer,
-      contentType: file.mimetype || 'application/pdf',
-    });
-
-    const record = this.jobStore.createQueuedJob({
+    const preparedJob = await this.prepareUploadJob({
       jobId,
+      userId: session.user.id,
+      universityId,
       fileKey,
       adapterKey,
+      clientPdfStreamHash,
+      pdfStreamHash: fingerprint.hash,
+      fingerprintAlgorithm: fingerprint.algorithmVersion,
+      streamCount: fingerprint.streamCount,
     });
 
-    await this.queueProducer.enqueuePdfParseJob({
-      jobId,
-      fileKey,
-      adapterKey,
-    });
+    if (preparedJob.kind === 'existing') {
+      return toUploadResponse(preparedJob.record);
+    }
+
+    const record = preparedJob.record;
+    const storageFileKey = record.fileKey ?? fileKey;
+
+    try {
+      await this.storage.putObject({
+        key: storageFileKey,
+        body: file.buffer,
+        contentType: file.mimetype || 'application/pdf',
+      });
+    } catch (error) {
+      await this.jobStore.markInfrastructureFailure(record.jobId, {
+        code: 'PDF_PARSE_UPLOAD_FAILED',
+        message: 'PDF parser upload could not be stored',
+        details: {
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      });
+      throw new InternalServerErrorException(
+        'PDF parser upload could not be stored',
+      );
+    }
+
+    try {
+      await this.queueProducer.enqueuePdfParseJob({
+        jobId: record.jobId,
+        fileKey: storageFileKey,
+        adapterKey,
+      });
+    } catch (error) {
+      await this.jobStore.markInfrastructureFailure(record.jobId, {
+        code: 'PDF_PARSE_ENQUEUE_FAILED',
+        message: 'PDF parser job could not be enqueued',
+        details: {
+          cause: error instanceof Error ? error.message : String(error),
+        },
+      });
+      throw new InternalServerErrorException(
+        'PDF parser job could not be enqueued',
+      );
+    }
 
     return {
-      ...record,
-      statusUrl: `/pdf-parser/jobs/${jobId}`,
+      jobId: record.jobId,
+      fileKey: record.fileKey,
+      adapterKey: record.adapterKey,
+      status: record.status,
+      result: record.result,
+      error: record.error,
+      moduleGroupingId: record.moduleGroupingId,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+      statusUrl: `/pdf-parser/jobs/${record.jobId}`,
     };
   }
 
-  @Public()
+  private async prepareUploadJob(
+    input: PrepareUploadJobInput,
+  ): Promise<PreparedUploadJob> {
+    try {
+      return {
+        kind: 'pending',
+        record: await this.jobStore.createQueuedJob(input),
+      };
+    } catch (error) {
+      const duplicate = await this.jobStore.findDuplicate({
+        userId: input.userId,
+        universityId: input.universityId,
+        adapterKey: input.adapterKey,
+        fingerprintAlgorithm: input.fingerprintAlgorithm,
+        pdfStreamHash: input.pdfStreamHash,
+      });
+
+      if (!duplicate) {
+        throw error;
+      }
+
+      if (duplicate.status !== 'failed') {
+        return { kind: 'existing', record: duplicate };
+      }
+
+      return {
+        kind: 'pending',
+        record: await this.jobStore.retryFailedDuplicate({
+          jobId: duplicate.jobId,
+          fileKey: input.fileKey,
+          adapterKey: input.adapterKey,
+          clientPdfStreamHash: input.clientPdfStreamHash,
+          pdfStreamHash: input.pdfStreamHash,
+          fingerprintAlgorithm: input.fingerprintAlgorithm,
+          streamCount: input.streamCount,
+        }),
+      };
+    }
+  }
+
   @Get('jobs/:jobId')
   @ApiOperation({
-    summary: 'Get temporary PDF parser job status and result',
+    summary: 'Get PDF parser job status and result metadata',
     description:
-      'Temporary in-memory status endpoint for local Swagger testing. Data is lost when the backend restarts.',
+      'Reads persisted parser job status scoped to the authenticated user.',
   })
   @ApiOkResponse({ type: PdfParserJobResponseDto })
-  getJob(@Param('jobId') jobId: string): PdfParserJobResponseDto {
-    const job = this.jobStore.findJob(jobId);
+  async getJob(
+    @CurrentSession() session: SessionData,
+    @Param('jobId') jobId: string,
+  ): Promise<PdfParserJobResponseDto> {
+    const job = await this.jobStore.findJob(jobId, { userId: session.user.id });
     if (!job) {
       throw new NotFoundException(`PDF parser job not found: ${jobId}`);
     }
 
     return job;
+  }
+
+  @Get('jobs/:jobId/result')
+  @ApiOperation({
+    summary: 'Get completed PDF parser result',
+    description:
+      'Returns persisted import candidates only for completed jobs owned by the authenticated user.',
+  })
+  @ApiOkResponse({ type: Object })
+  async getJobResult(
+    @CurrentSession() session: SessionData,
+    @Param('jobId') jobId: string,
+  ): Promise<PdfParserResult> {
+    const job = await this.jobStore.findJob(jobId, { userId: session.user.id });
+    if (!job || job.status !== 'completed' || !job.result) {
+      throw new NotFoundException(`PDF parser result not found: ${jobId}`);
+    }
+
+    return job.result;
   }
 
   @Public()
@@ -135,14 +351,13 @@ export class PdfParserController {
   @UseGuards(WorkerCallbackAuthGuard)
   @ApiOperation({ summary: 'Receive final PDF parser worker callback' })
   @HttpCode(HttpStatus.ACCEPTED)
-  receiveCallback(
+  async receiveCallback(
     @Param('jobId') jobId: string,
     @Body() body: PdfParserCallbackDto,
-  ) {
+  ): Promise<{ accepted: true; jobId: string }> {
     const callback = validatePdfParserCallback(body);
-    this.jobStore.recordCallback(jobId, callback);
+    await this.jobStore.recordCallback(jobId, callback);
 
-    // TODO: Persist parser job status and surface import candidates to the UI.
     return { accepted: true, jobId };
   }
 }
@@ -153,6 +368,29 @@ interface UploadedPdfFile {
   buffer: Buffer;
   size: number;
 }
+
+interface PdfParserLookupRequestBody {
+  universityId?: unknown;
+  adapterKey?: unknown;
+  fingerprintAlgorithm?: unknown;
+  pdfStreamHash?: unknown;
+}
+
+interface PrepareUploadJobInput {
+  jobId: string;
+  userId: string;
+  universityId: string;
+  fileKey: string;
+  adapterKey: string;
+  clientPdfStreamHash?: string;
+  pdfStreamHash: string;
+  fingerprintAlgorithm: string;
+  streamCount: number;
+}
+
+type PreparedUploadJob =
+  | { kind: 'pending'; record: PdfParserJobRecord }
+  | { kind: 'existing'; record: PdfParserJobRecord };
 
 function validateUploadedPdf(
   file: UploadedPdfFile | undefined,
@@ -172,6 +410,23 @@ function validateUploadedPdf(
   }
 }
 
+function toUploadResponse(
+  record: PdfParserJobRecord,
+): PdfParserUploadResponseDto {
+  return {
+    jobId: record.jobId,
+    fileKey: record.fileKey,
+    adapterKey: record.adapterKey,
+    status: record.status,
+    result: record.result,
+    error: record.error,
+    moduleGroupingId: record.moduleGroupingId,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    statusUrl: `/pdf-parser/jobs/${record.jobId}`,
+  };
+}
+
 function normalizeAdapterKey(adapterKeyInput: string | undefined): string {
   const adapterKey = adapterKeyInput?.trim() || 'up';
   if (adapterKey !== 'up') {
@@ -179,6 +434,80 @@ function normalizeAdapterKey(adapterKeyInput: string | undefined): string {
   }
 
   return adapterKey;
+}
+
+function validateLookupRequest(body: PdfParserLookupRequestBody): {
+  universityId: string;
+  adapterKey: string;
+  fingerprintAlgorithm: string;
+  pdfStreamHash: string;
+} {
+  const adapterKey =
+    typeof body.adapterKey === 'string'
+      ? normalizeAdapterKey(body.adapterKey)
+      : normalizeAdapterKey(undefined);
+  const universityId = validateUuid(body.universityId, 'universityId');
+  const fingerprintAlgorithm = validateFingerprintAlgorithm(
+    body.fingerprintAlgorithm,
+  );
+  const pdfStreamHash = normalizeRequiredHexHash(
+    body.pdfStreamHash,
+    'pdfStreamHash',
+  );
+
+  return {
+    universityId,
+    adapterKey,
+    fingerprintAlgorithm,
+    pdfStreamHash,
+  };
+}
+
+function validateFingerprintAlgorithm(value: unknown): string {
+  if (value !== PDF_STREAM_FINGERPRINT_ALGORITHM_VERSION) {
+    throw new BadRequestException(
+      `Unsupported fingerprint algorithm: ${String(value)}`,
+    );
+  }
+
+  return value;
+}
+
+function validateOptionalClientAlgorithm(value: unknown): void {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+
+  validateFingerprintAlgorithm(value);
+}
+
+function validateUuid(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !UUID_PATTERN.test(value.trim())) {
+    throw new BadRequestException(`${fieldName} must be a UUID`);
+  }
+
+  return value.trim();
+}
+
+function normalizeRequiredHexHash(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !HEX_SHA_256_PATTERN.test(value.trim())) {
+    throw new BadRequestException(
+      `${fieldName} must be a 64-character hex hash`,
+    );
+  }
+
+  return value.trim().toLowerCase();
+}
+
+function normalizeOptionalHexHash(
+  value: unknown,
+  fieldName: string,
+): string | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  return normalizeRequiredHexHash(value, fieldName);
 }
 
 function buildFileKey(jobId: string, originalName: string): string {
@@ -204,3 +533,7 @@ function validatePdfParserCallback(
     issues: result.error.issues,
   });
 }
+
+const HEX_SHA_256_PATTERN = /^[0-9a-f]{64}$/i;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/apps/backend/src/pdf-parser/pdf-parser.controller.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.controller.ts
@@ -201,8 +201,8 @@ function assertExactKeys(
     throw new BadRequestException(`${label} must be an object`);
   }
 
-  const actualKeys = Object.keys(value).sort();
-  const expected = expectedKeys.slice().sort();
+  const actualKeys = Object.keys(value).sort((a, b) => a.localeCompare(b));
+  const expected = expectedKeys.slice().sort((a, b) => a.localeCompare(b));
 
   if (!hasSameKeys(actualKeys, expected)) {
     throw new BadRequestException(

--- a/apps/backend/src/pdf-parser/pdf-parser.module.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { JobsModule } from '../jobs/jobs.module';
+import { PdfParserController } from './pdf-parser.controller';
+
+@Module({
+  imports: [JobsModule],
+  controllers: [PdfParserController],
+})
+export class PdfParserModule {}

--- a/apps/backend/src/pdf-parser/pdf-parser.module.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
+import { EventImportKeyService } from '../Events/event-import-key.service';
 import { JobsModule } from '../jobs/jobs.module';
 import { StorageModule } from '../storage/storage.module';
 import { EventImporter } from './event-importer.service';
 import { ModuleResolver } from './module-resolver.service';
 import { ParserResultImporter } from './parser-result-importer.service';
+import { PdfParseSubmission } from './pdf-parse-submission';
 import { PdfParserController } from './pdf-parser.controller';
 import { PdfParserFingerprintService } from './pdf-parser-fingerprint.service';
 import { PdfParserJobStoreService } from './pdf-parser-job-store.service';
@@ -12,9 +14,11 @@ import { PdfParserJobStoreService } from './pdf-parser-job-store.service';
   imports: [JobsModule, StorageModule],
   controllers: [PdfParserController],
   providers: [
+    EventImportKeyService,
     EventImporter,
     ModuleResolver,
     ParserResultImporter,
+    PdfParseSubmission,
     PdfParserFingerprintService,
     PdfParserJobStoreService,
   ],

--- a/apps/backend/src/pdf-parser/pdf-parser.module.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { JobsModule } from '../jobs/jobs.module';
+import { StorageModule } from '../storage/storage.module';
 import { PdfParserController } from './pdf-parser.controller';
+import { PdfParserJobStoreService } from './pdf-parser-job-store.service';
 
 @Module({
-  imports: [JobsModule],
+  imports: [JobsModule, StorageModule],
   controllers: [PdfParserController],
+  providers: [PdfParserJobStoreService],
 })
 export class PdfParserModule {}

--- a/apps/backend/src/pdf-parser/pdf-parser.module.ts
+++ b/apps/backend/src/pdf-parser/pdf-parser.module.ts
@@ -1,12 +1,22 @@
 import { Module } from '@nestjs/common';
 import { JobsModule } from '../jobs/jobs.module';
 import { StorageModule } from '../storage/storage.module';
+import { EventImporter } from './event-importer.service';
+import { ModuleResolver } from './module-resolver.service';
+import { ParserResultImporter } from './parser-result-importer.service';
 import { PdfParserController } from './pdf-parser.controller';
+import { PdfParserFingerprintService } from './pdf-parser-fingerprint.service';
 import { PdfParserJobStoreService } from './pdf-parser-job-store.service';
 
 @Module({
   imports: [JobsModule, StorageModule],
   controllers: [PdfParserController],
-  providers: [PdfParserJobStoreService],
+  providers: [
+    EventImporter,
+    ModuleResolver,
+    ParserResultImporter,
+    PdfParserFingerprintService,
+    PdfParserJobStoreService,
+  ],
 })
 export class PdfParserModule {}


### PR DESCRIPTION
Split from #470.

## Summary
- Adds backend PDF parser endpoints, job storage, fingerprinting, and import flow.
- Adds parse-job persistence and migration changes.
- Adds event/module import services and validation plumbing for parser output.

## Review focus
- Controller API and callback flow.
- Job persistence and idempotency.
- Import behavior for events/modules and validation state.

## Notes
- Generated from origin/feat/queue-worker on top of origin/dev.
- Migration commits are replayed with backend path filters and final drizzle files aligned from the source branch.
